### PR TITLE
Pre-allocate result of invlink for PDMatDistribution

### DIFF
--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -317,7 +317,8 @@ function invlink(d::PDMatDistribution, Y::AbstractMatrix{T}) where {T<:Real}
     for m in 1:size(X, 1)
         X[m, m] = exp(X[m, m])
     end
-    return LowerTriangular(X) * LowerTriangular(X)'
+    Z = similar(X)
+    return mul!(Z, LowerTriangular(X), LowerTriangular(X)')
 end
 
 function logpdf_with_trans(


### PR DESCRIPTION
This solves problems with using `T = Real` where automatically determining the output type leads to `Int`. The problem first showed up in https://github.com/TuringLang/Turing.jl/pull/611.