### PR TITLE
Fix eps, Real and AD support

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ Reexport 0.2.0
 Distributions 0.16.0
 StatsFuns 0.7.0
 MappedArrays
+Requires


### PR DESCRIPTION
This PR defines `_eps` for `<:ForwardDiff.Dual{<:Any, Real}` and `Flux.Tracker.TrackedReal{<:Any}` using Requires.jl for the reason explained in https://github.com/TuringLang/Turing.jl/pull/611. 