### PR TITLE
Fix Float32 support

### DIFF
--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -17,7 +17,11 @@ export  TransformDistribution,
         logpdf_with_trans
 
 _eps(::Type{T}) where {T} = eps(T)
-_eps(::Type{Real}) = eps(Float64)
+@static if Sys.WORDSIZE == 64
+    _eps(::Type{Real}) = eps(Float64)
+else
+    _eps(::Type{Real}) = eps(Float32)
+end
 function __init__()
     @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" @eval begin
         _eps(::Type{<:ForwardDiff.Dual{<:Any, Real}}) = _eps(Real)


### PR DESCRIPTION
This is a bug fix. I noticed some test failure happening in Turing on 32 bit machines on AppVeyor with NUTS. I am not sure if this is the cause or not, but using `eps(Float64)` is definitely a bug here for 32 bit machines.