### PR TITLE
Dirichlet link and invlink Jacobians

### DIFF
--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -235,7 +235,7 @@ function link_jacobian(
         z = (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
         dydxt[k,k] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
         for i in 1:k-1
-		    dydxt[i,k] = (1/z + 1/(1-z)) * (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)^2
+            dydxt[i,k] = (1/z + 1/(1-z)) * (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)^2
 		end
     end
     @inbounds sum_tmp += x[K - 1]

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -16,7 +16,7 @@ export  TransformDistribution,
         invlink,
         logpdf_with_trans,
         link_jacobian,
-        invlink_jacobian
+        invlink_jacobian,
         transform,
         forward,
         logabsdetjac,

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -4,7 +4,6 @@ using Reexport, Requires
 @reexport using Distributions
 using StatsFuns
 using LinearAlgebra
-using MappedArrays
 using Roots
 
 export  TransformDistribution,
@@ -389,7 +388,7 @@ function logpdf_with_trans(
 )
     T = eltype(x)
     ϵ = _eps(T)
-    lp = logpdf(d, x .+ ϵ)
+    lp = logpdf(d, mappedarray(x -> x + ϵ, x))
     if transform
         K = length(x)
 

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -4,6 +4,7 @@ using Reexport, Requires
 @reexport using Distributions
 using StatsFuns
 using LinearAlgebra
+using MappedArrays
 using Roots
 
 export  TransformDistribution,

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -15,6 +15,8 @@ export  TransformDistribution,
         link,
         invlink,
         logpdf_with_trans,
+        link_jacobian,
+        invlink_jacobian
         transform,
         forward,
         logabsdetjac,

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -394,7 +394,7 @@ function logpdf_with_trans(
 )
     T = eltype(x)
     ϵ = _eps(T)
-    lp = logpdf(d, mappedarray(x->x+ϵ, x))
+    lp = logpdf(d, x .+ ϵ)
     if transform
         K = length(x)
 

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -236,7 +236,7 @@ function link_jacobian(
         dydxt[k,k] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
         for i in 1:k-1
             dydxt[i,k] = (1/z + 1/(1-z)) * (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)^2
-		end
+        end
     end
     @inbounds sum_tmp += x[K - 1]
     @inbounds if !proj

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -213,6 +213,44 @@ function link(
     return y
 end
 
+function link_jacobian(
+    d::SimplexDistribution, 
+    x::AbstractVector{T}, 
+    ::Type{Val{proj}} = Val{true}
+) where {T<:Real, proj}
+    y, K = similar(x), length(x)
+    dydxt = similar(x, length(x), length(x))
+    dydxt .= 0
+    ϵ = _eps(T)
+    sum_tmp = zero(T)
+
+    @inbounds z = x[1] * (one(T) - 2ϵ) + ϵ # z ∈ [ϵ, 1-ϵ]
+    @inbounds y[1] = StatsFuns.logit(z) + log(T(K - 1))
+    dydxt[1,1] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)
+    @inbounds @simd for k in 2:(K - 1)
+        sum_tmp += x[k - 1]
+        # z ∈ [ϵ, 1-ϵ]
+        # x[k] = 0 && sum_tmp = 1 -> z ≈ 1
+        z = (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
+        y[k] = StatsFuns.logit(z) + log(T(K - k))
+	    dydxt[k,k] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
+	    for i in 1:k-1
+		    dydxt[i,k] = (1/z + 1/(1-z)) * (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)^2
+		end
+    end
+    @inbounds sum_tmp += x[K - 1]
+    @inbounds if proj
+        y[K] = zero(T)
+    else
+        y[K] = one(T) - sum_tmp - x[K]
+	    for i in 1:K
+		    dydxt[i,K] = -1
+		end        
+    end
+
+    return UpperTriangular(dydxt)'
+end
+
 # Vectorised implementation of the above.
 function link(
     d::SimplexDistribution,
@@ -265,6 +303,58 @@ function invlink(
         x[K] = _clamp(one(T) - sum_tmp - y[K], d)
     end
     return x
+end
+
+function invlink_jacobian(
+    d::SimplexDistribution, 
+    y::AbstractVector{T}, 
+    ::Type{Val{proj}} = Val{true}
+) where {T<:Real, proj}
+    x, K = similar(y), length(y)
+    dxdy = similar(y, length(y), length(y))
+    dxdy .= 0
+
+    ϵ = _eps(T)
+    @inbounds z = StatsFuns.logistic(y[1] - log(T(K - 1)))
+    unclamped_x = (z - ϵ) / (one(T) - 2ϵ)
+    @inbounds x[1] = _clamp(unclamped_x, d)
+    if unclamped_x == x[1]
+        dxdy[1,1] = z * (1 - z) / (one(T) - 2ϵ)
+    end
+    sum_tmp = zero(T)
+    @inbounds @simd for k = 2:(K - 1)
+        z = StatsFuns.logistic(y[k] - log(T(K - k)))
+        sum_tmp += x[k-1]
+        unclamped_x = ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ
+        x[k] = _clamp(unclamped_x, d)
+        if unclamped_x == x[k]
+            dxdy[k,k] = z * (1 - z) * ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ)
+            for i in 1:k-1
+                for j in i:k-1
+                    dxdy[k,i] += -dxdy[j,i] * z / (one(T) - 2ϵ)
+                end
+            end
+        end
+    end
+    @inbounds sum_tmp += x[K - 1]
+    @inbounds if proj
+    	unclamped_x = one(T) - sum_tmp
+        x[K] = _clamp(unclamped_x, d)
+    else
+    	unclamped_x = one(T) - sum_tmp - y[K]
+        x[K] = _clamp(unclamped_x, d)
+        if unclamped_x == x[K]
+            dxdy[K,K] = -1
+        end
+    end
+    if unclamped_x == x[K]
+        for i in 1:K-1
+            for j in i:K-1
+                dxdy[K,i] += -dxdy[j,i]
+            end
+        end
+    end
+    return LowerTriangular(dxdy)
 end
 
 # Vectorised implementation of the above.

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -247,5 +247,7 @@ end
         @test @aeq jacobian(g2, y) Bijectors.invlink_jacobian(dist, y, Val{false})
         @test @aeq Bijectors.link_jacobian(dist, x, Val{false}) * Bijectors.invlink_jacobian(dist, y, Val{false}) I
     end
-    test_link_and_invlink()
+    for i in 1:4
+        test_link_and_invlink()
+    end
 end

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -1,7 +1,7 @@
 using Test
 using Bijectors
 using ForwardDiff: derivative, jacobian
-using LinearAlgebra: logabsdet, I
+using LinearAlgebra: logabsdet, I, norm
 using Random
 
 Random.seed!(123)
@@ -220,3 +220,32 @@ r2 = [-1., -2., 0.0]
 # test logpdf_with_trans
 #@test logpdf_with_trans(d, invlink(d, r), true) -1999.30685281944 1e-9 ≈ # atol=NaN
 @test logpdf_with_trans(d, invlink(d, r2), true) ≈ -3.760398892580863 atol=1e-9
+
+macro aeq(x, y)
+    return quote
+        x = $(esc(x))
+        y = $(esc(y))
+        norm = $(esc(:norm))
+        norm(x - y) <= 1e-10
+    end
+end
+
+@testset "Dirichlet Jacobians" begin
+    function test_link_and_invlink()
+        dist = Dirichlet(4, 4)
+        x = rand(dist)
+        y = link(dist, x)
+
+        f1 = x -> link(dist, x, Val{true})
+        f2 = x -> link(dist, x, Val{false})
+        g1 = y -> invlink(dist, y, Val{true})
+        g2 = y -> invlink(dist, y, Val{false})
+
+        @test @aeq jacobian(f1, x) Bijectors.link_jacobian(dist, x, Val{true})
+        @test @aeq jacobian(f2, x) Bijectors.link_jacobian(dist, x, Val{false})
+        @test @aeq jacobian(g1, y) Bijectors.invlink_jacobian(dist, y, Val{true})
+        @test @aeq jacobian(g2, y) Bijectors.invlink_jacobian(dist, y, Val{false})
+        @test @aeq Bijectors.link_jacobian(dist, x, Val{false}) * Bijectors.invlink_jacobian(dist, y, Val{false}) I
+    end
+    test_link_and_invlink()
+end


### PR DESCRIPTION
This PR defines the Jacobians of the `link` and `invlink` functions for the Dirichlet distribution. This is a step towards solving https://github.com/TuringLang/Turing.jl/issues/850.

```julia
using ForwardDiff, Bijectors, Distributions, BenchmarkTools, Test, LinearAlgebra

const dist = Dirichlet(4, 4)
x = rand(dist)
y = link(dist, x)

f1 = x -> link(dist, x, Val{true})
f2 = x -> link(dist, x, Val{false})
g1 = y -> invlink(dist, y, Val{true})
g2 = y -> invlink(dist, y, Val{false})

macro eq(x, y)
	return quote
		x = $(esc(x))
		y = $(esc(y))
		norm = $(esc(:norm))
		norm(x - y) <= 1e-10
	end
end

@test @eq ForwardDiff.jacobian(f1, x) Bijectors.link_jacobian(dist, x, Val{true})
@test @eq ForwardDiff.jacobian(f2, x) Bijectors.link_jacobian(dist, x, Val{false})
@test @eq ForwardDiff.jacobian(g1, y) Bijectors.invlink_jacobian(dist, y, Val{true})
@test @eq ForwardDiff.jacobian(g2, y) Bijectors.invlink_jacobian(dist, y, Val{false})
@test @eq Bijectors.link_jacobian(dist, x, Val{false}) * Bijectors.invlink_jacobian(dist, y, Val{false}) I

@btime ForwardDiff.jacobian($f1, $x);
# 498 ns
@btime Bijectors.link_jacobian($dist, $x, Val{true});
# 139 ns

@btime ForwardDiff.jacobian($g1, $y);
# 559 ns
@btime Bijectors.invlink_jacobian($dist, $y, Val{true});
# 184 ns
```