### PR TITLE
Wct/tidy up pdmatdistribution

### DIFF
--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -339,7 +339,7 @@ function logpdf_with_trans(d::PDMatDistribution, X::AbstractMatrix{<:Real}, tran
     lp = logpdf(d, X)
     if transform && isfinite(lp)
         U = cholesky(X).U
-        lp += sum(i->(dim(d) - i + 2) * log(U[i, i]), 1:dim(d))
+        lp += sum((dim(d) .- (1:dim(d)) .+ 2) .* log.(view(U, diagind(U))))
         lp += dim(d) * log(2)
     end
     return lp

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -339,10 +339,8 @@ function logpdf_with_trans(d::PDMatDistribution, X::AbstractMatrix{<:Real}, tran
     lp = logpdf(d, X)
     if transform && isfinite(lp)
         U = cholesky(X).U
-        @inbounds @simd for i in 1:dim(d)
-            lp += (dim(d) - i + 2) * log(U[i, i])
-        end
-        lp += dim(d) * log(eltype(X)(2))
+        lp += sum(i->(dim(d) - i + 2) * log(U[i, i]), 1:dim(d))
+        lp += dim(d) * log(2)
     end
     return lp
 end


### PR DESCRIPTION
Tidies up the functionality associated with `PDMatDistribution`: `link`, `invlink`, and `logpdf_with_trans` to be more readable, and the utilise higher-order functions rather than for-loops. Will underake benchmarking on request.

Results for 100-dimensional Inverse Wishart distribution on this branch:
```julia
julia> @benchmark logpdf($d, $X)
BenchmarkTools.Trial:
  memory estimate:  234.72 KiB
  allocs estimate:  10
  --------------
  minimum time:     111.637 μs (0.00% GC)
  median time:      229.804 μs (0.00% GC)
  mean time:        262.921 μs (11.77% GC)
  maximum time:     52.052 ms (99.46% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark logpdf_with_trans($d, $X, false)
BenchmarkTools.Trial:
  memory estimate:  234.72 KiB
  allocs estimate:  10
  --------------
  minimum time:     111.674 μs (0.00% GC)
  median time:      233.511 μs (0.00% GC)
  mean time:        269.055 μs (12.01% GC)
  maximum time:     52.979 ms (99.51% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark logpdf_with_trans($d, $X, true)
BenchmarkTools.Trial:
  memory estimate:  314.06 KiB
  allocs estimate:  21
  --------------
  minimum time:     165.959 μs (0.00% GC)
  median time:      346.826 μs (0.00% GC)
  mean time:        412.454 μs (10.37% GC)
  maximum time:     54.751 ms (99.42% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark link($d, $X)
BenchmarkTools.Trial:
  memory estimate:  235.94 KiB
  allocs estimate:  18
  --------------
  minimum time:     70.914 μs (0.00% GC)
  median time:      186.114 μs (0.00% GC)
  mean time:        225.070 μs (14.74% GC)
  maximum time:     53.348 ms (99.63% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> Y = link(d, X);

julia> @benchmark invlink($d, $Y)
BenchmarkTools.Trial:
  memory estimate:  157.64 KiB
  allocs estimate:  13
  --------------
  minimum time:     51.095 μs (0.00% GC)
  median time:      119.603 μs (0.00% GC)
  mean time:        143.686 μs (16.31% GC)
  maximum time:     52.469 ms (99.64% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

Results on master:
```julia
julia> @benchmark logpdf($d, $X)
BenchmarkTools.Trial:
  memory estimate:  234.72 KiB
  allocs estimate:  10
  --------------
  minimum time:     112.248 μs (0.00% GC)
  median time:      232.940 μs (0.00% GC)
  mean time:        265.025 μs (11.41% GC)
  maximum time:     49.869 ms (99.50% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark logpdf_with_trans($d, $X, false)
BenchmarkTools.Trial:
  memory estimate:  234.72 KiB
  allocs estimate:  10
  --------------
  minimum time:     111.320 μs (0.00% GC)
  median time:      237.343 μs (0.00% GC)
  mean time:        285.415 μs (11.32% GC)
  maximum time:     52.927 ms (99.40% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark logpdf_with_trans($d, $X, true)
BenchmarkTools.Trial:
  memory estimate:  313.03 KiB
  allocs estimate:  16
  --------------
  minimum time:     168.684 μs (0.00% GC)
  median time:      346.644 μs (0.00% GC)
  mean time:        400.042 μs (10.79% GC)
  maximum time:     53.808 ms (99.17% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark link($d, $X)
BenchmarkTools.Trial:
  memory estimate:  234.72 KiB
  allocs estimate:  10
  --------------
  minimum time:     70.830 μs (0.00% GC)
  median time:      194.460 μs (0.00% GC)
  mean time:        234.802 μs (15.29% GC)
  maximum time:     56.388 ms (99.57% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> Y = link(d, X);

julia> @benchmark invlink($d, $Y)
BenchmarkTools.Trial:
  memory estimate:  156.42 KiB
  allocs estimate:  5
  --------------
  minimum time:     41.827 μs (0.00% GC)
  median time:      116.073 μs (0.00% GC)
  mean time:        141.185 μs (16.86% GC)
  maximum time:     52.851 ms (99.67% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

My reading of these results is that performance is broadly the same. Personally I feel that the improvement in readability of the code is worth any minor changes in perf.