### PR TITLE
Wishart perf and stability

### DIFF
--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -7,7 +7,6 @@ using LinearAlgebra
 using MappedArrays
 
 export  TransformDistribution,
-        RealDistribution,
         PositiveDistribution,
         UnitDistribution,
         SimplexDistribution,
@@ -350,7 +349,7 @@ function logpdf_with_trans(
     p = dim(d)
     Xcf = cholesky(X, check=false)
     if !issuccess(Xcf)
-        Xcf = cholesky(X + diagm(0 => fill(sqrt(eps(T)) * norm(X, Inf), size(X, 1))))
+        Xcf = cholesky(X + (eps(T) * norm(X)) * I)
     end
     lp = 0.5 * ((df - (p + 1)) * logdet(Xcf) - tr(d.S \ X)) - d.c0
     if transform && isfinite(lp)
@@ -373,7 +372,7 @@ function logpdf_with_trans(
     df = d.df
     Xcf = cholesky(X, check=false)
     if !issuccess(Xcf)
-        Xcf = cholesky(X + Diagonal(fill(eps(T), size(X, 1))))
+        Xcf = cholesky(X + (eps(T) * norm(X)) * I)
     end
     # we use the fact: tr(Ψ * inv(X)) = tr(inv(X) * Ψ) = tr(X \ Ψ)
     Ψ = Matrix(d.Ψ)

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -328,7 +328,7 @@ function link(d::PDMatDistribution, X::AbstractMatrix{<:Real})
     return Y
 end
 
-function invlink(d::PDMatDistribution, Y::AbstractMatrix{T}) where {T<:Real}
+function invlink(d::PDMatDistribution, Y::AbstractMatrix{<:Real})
     X = copy(Y)
     X[diagind(X)] .= exp.(view(X, diagind(X)))
     return LowerTriangular(X) * LowerTriangular(X)'


### PR DESCRIPTION
This PR offsets the matrix when `logpdf_with_trans` for `Wishart` and `InverseWishart` fails. It also inlines the `logpdf` call to reuse the `Cholesky` for performance. I unrolled the loop version of the `logpdf_with_trans` since I found it faster when doing reverse_diff in Turing.