### PR TITLE
Improves type-stability of `bijector(d::Distribution)`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -476,10 +476,6 @@ end
 (b::DistributionBijector)(x) = link(b.dist, x)
 (ib::Inversed{<:DistributionBijector})(y) = invlink(ib.orig.dist, y)
 
-
-"Returns the constrained-to-unconstrained bijector for distribution `d`."
-bijector(d::Distribution) = DistributionBijector(d)
-
 # Transformed distributions
 struct TransformedDistribution{D, B, V} <: Distribution{V, Continuous} where {D<:Distribution{V, Continuous}, B<:Bijector}
     dist::D
@@ -514,6 +510,7 @@ transformed(d) = transformed(d, bijector(d))
 
 Returns the constrained-to-unconstrained bijector for distribution `d`.
 """
+bijector(d::Distribution) = DistributionBijector(d)
 bijector(d::Normal) = IdentityBijector
 bijector(d::MvNormal) = IdentityBijector
 bijector(d::PositiveDistribution) = Log()

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -521,7 +521,9 @@ bijector(d::MvLogNormal) = Log()
 bijector(d::SimplexDistribution) = simplex_b_proj
 bijector(d::KSOneSided) = Logit(zero(eltype(d)), zero(eltype(d)))
 
-const BoundedDistribution = Union{Arcsine, Biweight, Cosine, Epanechnikov, Beta, NoncentralBeta}
+const BoundedDistribution = Union{
+    Arcsine, Biweight, Cosine, Epanechnikov, Beta, NoncentralBeta
+}
 bijector(d::BoundedDistribution) = Logit(minimum(d), maximum(d))
 
 const LowerboundedDistribution = Union{Pareto, Levy}

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -125,17 +125,26 @@ struct NonInvertibleBijector{AD} <: ADBijector{AD} end
         d = Truncated(Normal(), -1, 1)
         b = bijector(d)
         x = rand(d)
-        @test b(x) == link(d, x)
+        y = b(x)
+        @test y ≈ link(d, x)
+        @test inv(b)(y) ≈ x
+        @test logabsdetjac(b, x) ≈ logpdf_with_trans(d, x, false) - logpdf_with_trans(d, x, true)
 
         d = Truncated(Normal(), -Inf, 1)
         b = bijector(d)
         x = rand(d)
-        @test b(x) == link(d, x)
+        y = b(x)
+        @test y ≈ link(d, x)
+        @test inv(b)(y) ≈ x
+        @test logabsdetjac(b, x) ≈ logpdf_with_trans(d, x, false) - logpdf_with_trans(d, x, true)
 
         d = Truncated(Normal(), 1, Inf)
         b = bijector(d)
         x = rand(d)
-        @test b(x) == link(d, x)
+        y = b(x)
+        @test y ≈ link(d, x)
+        @test inv(b)(y) ≈ x
+        @test logabsdetjac(b, x) ≈ logpdf_with_trans(d, x, false) - logpdf_with_trans(d, x, true)
     end
 
     @testset "Multivariate" begin


### PR DESCRIPTION
Related to #40. Also removes the use of a couple of, now, unnecessary `eval` calls. 

Before:
```julia
julia> for d in uni_dists
           c = @code_typed bijector(d)
           if (c.second isa Union) || (c.second == Any)
               println("-----------------")
               println(d, ": ", c.second)
               println("(", minimum(d), ", ", maximum(d), ")")
               println(bijector(d))
           end
       end
-----------------
Arcsine{Float64}(a=2.0, b=4.0): Union{Identity, Logit{Float64}, Composed}
(2.0, 4.0)
Bijectors.Logit{Float64}(2.0, 4.0)
-----------------
Biweight{Float64}(μ=0.0, σ=1.0): Union{Identity, Logit{Float64}, Composed}
(-1.0, 1.0)
Bijectors.Logit{Float64}(-1.0, 1.0)
-----------------
Cosine{Float64}(μ=0.0, σ=1.0): Union{Identity, Logit{Float64}, Composed}
(-1.0, 1.0)
Bijectors.Logit{Float64}(-1.0, 1.0)
-----------------
Epanechnikov{Float64}(μ=0.0, σ=1.0): Union{Identity, Logit{Float64}, Composed}
(-1.0, 1.0)
Bijectors.Logit{Float64}(-1.0, 1.0)
-----------------
Levy{Float64}(μ=0.0, σ=1.0): Union{Identity, Composed{Tuple{Shift{Float64},Log}}}
(0.0, Inf)
Composed{Tuple{Bijectors.Shift{Float64},Bijectors.Log}}((Bijectors.Shift{Float64}(-0.0), Bijectors.Log()))
-----------------
Pareto{Float64}(α=1.0, θ=1.0): Union{Identity, Composed{Tuple{Shift{Float64},Log}}}
(1.0, Inf)
Composed{Tuple{Bijectors.Shift{Float64},Bijectors.Log}}((Bijectors.Shift{Float64}(-1.0), Bijectors.Log()))
-----------------
Truncated(Normal{Float64}(μ=0.0, σ=1.0), range=(-Inf, 2.0)): Union{Identity, Logit{Float64}, Composed}
(-Inf, 2.0)
Composed{Tuple{Bijectors.Scale{Float64},Composed{Tuple{Bijectors.Shift{Float64},Bijectors.Log}}}}((Bijectors.Scale{Float64}(-1.0), Composed{Tuple{Bijectors.Shift{Float64},Bijectors.Log}}((Bijectors.Shift{Float64}(2.0), Bijectors.Log()))))
```

After:
```julia
julia> for d in uni_dists
           c = @code_typed bijector(d)
           if (c.second isa Union) || (c.second == Any)
               println("-----------------")
               println(d, ": ", c.second)
               println("(", minimum(d), ", ", maximum(d), ")")
               println(bijector(d))
           end
       end
-----------------
Truncated(Normal{Float64}(μ=0.0, σ=1.0), range=(-Inf, 2.0)): Union{Identity, Logit{Float64}, Composed}
(-Inf, 2.0)
Composed{Tuple{Bijectors.Scale{Float64},Composed{Tuple{Bijectors.Shift{Float64},Bijectors.Log}}}}((Bijectors.Scale{Float64}(-1.0), Composed{Tuple{Bijectors.Shift{Float64},Bijectors.Log}}((Bijectors.Shift{Float64}(2.0), Bijectors.Log()))))
```