### PR TITLE
Add Julia compat section to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,9 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
+[compat]
+julia = "1"
+
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
Looks like they're awaiting a compat section on the repo before the release can go through, see [here](https://github.com/JuliaRegistries/General/pull/3061#issuecomment-526535282). This PR adds a Julia compat section bounded to version 1.