### PR TITLE
Do not use `Val` as type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,13 +335,13 @@ dim: 4
 
 julia> # Construct the transform
        bs = bijector.(dists)     # constrained-to-unconstrained bijectors for dists
-(Logit{Float64}(0.0, 1.0), Log{0}(), SimplexBijector{Val{true}}())
+(Logit{Float64}(0.0, 1.0), Log{0}(), SimplexBijector{true}())
 
 julia> ibs = inv.(bs)            # invert, so we get unconstrained-to-constrained
-(Inversed{Logit{Float64},0}(Logit{Float64}(0.0, 1.0)), Exp{0}(), Inversed{SimplexBijector{Val{true}},1}(SimplexBijector{Val{true}}()))
+(Inversed{Logit{Float64},0}(Logit{Float64}(0.0, 1.0)), Exp{0}(), Inversed{SimplexBijector{true},1}(SimplexBijector{true}()))
 
 julia> sb = Stacked(ibs, ranges) # => Stacked <: Bijector
-Stacked{Tuple{Inversed{Logit{Float64},0},Exp{0},Inversed{SimplexBijector{Val{true}},1}},3}((Inversed{Logit{Float64},0}(Logit{Float64}(0.0, 1.0)), Exp{0}(), Inversed{SimplexBijector{Val{true}},1}(SimplexBijector{Val{true}}())), (1:1, 2:2, 3:4))
+Stacked{Tuple{Inversed{Logit{Float64},0},Exp{0},Inversed{SimplexBijector{true},1}},3}((Inversed{Logit{Float64},0}(Logit{Float64}(0.0, 1.0)), Exp{0}(), Inversed{SimplexBijector{true},1}(SimplexBijector{true}())), (1:1, 2:2, 3:4))
 
 julia> # Mean-field normal with unconstrained-to-constrained stacked bijector
        td = transformed(d, sb);

--- a/src/bijectors/simplex.jl
+++ b/src/bijectors/simplex.jl
@@ -2,8 +2,7 @@
 # Simplex bijector #
 ####################
 struct SimplexBijector{T} <: Bijector{1} where {T} end
-SimplexBijector(proj::Bool) = SimplexBijector{Val{proj}}()
-SimplexBijector() = SimplexBijector(true)
+SimplexBijector() = SimplexBijector{true}()
 
 # The following implementations are basically just copy-paste from `invlink` and
 # `link` for `SimplexDistributions` but dropping the dependence on the `Distribution`.
@@ -14,7 +13,7 @@ function _clamp(x::T, b::Union{SimplexBijector, Inversed{<:SimplexBijector}}) wh
     return clamped_x
 end
 
-function (b::SimplexBijector{Val{proj}})(x::AbstractVector{T}) where {T, proj}
+function (b::SimplexBijector{proj})(x::AbstractVector{T}) where {T, proj}
     y, K = similar(x), length(x)
     @assert K > 1 "x needs to be of length greater than 1"
 
@@ -40,7 +39,7 @@ function (b::SimplexBijector{Val{proj}})(x::AbstractVector{T}) where {T, proj}
 end
 
 # Vectorised implementation of the above.
-function (b::SimplexBijector{Val{proj}})(X::AbstractMatrix{T}) where {T<:Real, proj}
+function (b::SimplexBijector{proj})(X::AbstractMatrix{T}) where {T<:Real, proj}
     Y, K, N = similar(X), size(X, 1), size(X, 2)
     @assert K > 1 "x needs to be of length greater than 1"
 
@@ -65,7 +64,7 @@ function (b::SimplexBijector{Val{proj}})(X::AbstractMatrix{T}) where {T<:Real, p
     return Y
 end
 
-function (ib::Inversed{<:SimplexBijector{Val{proj}}})(y::AbstractVector{T}) where {T, proj}
+function (ib::Inversed{<:SimplexBijector{proj}})(y::AbstractVector{T}) where {T, proj}
     x, K = similar(y), length(y)
     @assert K > 1 "x needs to be of length greater than 1"
 
@@ -89,7 +88,7 @@ function (ib::Inversed{<:SimplexBijector{Val{proj}}})(y::AbstractVector{T}) wher
 end
 
 # Vectorised implementation of the above.
-function (ib::Inversed{<:SimplexBijector{Val{proj}}})(
+function (ib::Inversed{<:SimplexBijector{proj}})(
     Y::AbstractMatrix{T}
 ) where {T<:Real, proj}
     X, K, N = similar(Y), size(Y, 1), size(Y, 2)

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -39,7 +39,7 @@ bijector(d::Normal) = Identity{0}()
 bijector(d::MvNormal) = Identity{1}()
 bijector(d::PositiveDistribution) = Log{0}()
 bijector(d::MvLogNormal) = Log{0}()
-bijector(d::SimplexDistribution) = SimplexBijector{Val{true}}()
+bijector(d::SimplexDistribution) = SimplexBijector{true}()
 bijector(d::KSOneSided) = Logit(zero(eltype(d)), one(eltype(d)))
 
 bijector_bounded(d, a=minimum(d), b=maximum(d)) = Logit(a, b)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -404,7 +404,7 @@ end
             # verify against AD
             # similar to what we do in test/transform.jl for Dirichlet
             if dist isa Dirichlet
-                b = Bijectors.SimplexBijector{Val{false}}()
+                b = Bijectors.SimplexBijector{false}()
                 x = rand(dist)
                 y = b(x)
                 @test log(abs(det(ForwardDiff.jacobian(b, x)))) ≈ logabsdetjac(b, x)


### PR DESCRIPTION
I guess the type parameter `Val{proj}` of `SimplexBijector` can just be replaced with `proj`. That seems a bit simpler to me.