### PR TITLE
Fix optional dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,11 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
 Distributions = "0.21.11"
-ForwardDiff = "0.10.3"
 MappedArrays = "0.2.2"
 Reexport = "0.2"
 Requires = "1"
 Roots = "0.8.4"
 StatsFuns = "0.8, 0.9.3"
-Tracker = "0.2.3"
 julia = "1"
 
 [extras]

--- a/src/bijectors/adbijector.jl
+++ b/src/bijectors/adbijector.jl
@@ -13,6 +13,7 @@ end
 
 # concrete implementations with optional dependencies ForwardDiff and Tracker
 function jacobian end
+const _jacobian = jacobian
 
 # TODO: allow batch-computation, especially for univariate case?
 "Computes the absolute determinant of the Jacobian of the inverse-transformation."

--- a/src/compat/forwarddiff.jl
+++ b/src/compat/forwarddiff.jl
@@ -1,21 +1,24 @@
-using .Bijectors
-import ForwardDiff
+module ForwardDiffCompat
 
-using .Bijectors: ForwardDiffAD
-import .Bijectors: _eps, jacobian
+using ..Bijectors: ADBijector, ForwardDiffAD, Inversed
+import ..Bijectors: _eps, _jacobian
 
-_eps(::Type{<:ForwardDiff.Dual{<:Any, Real}}) = _eps(Real)
+using ..ForwardDiff: Dual, derivative, jacobian
+
+_eps(::Type{<:Dual{<:Any, Real}}) = _eps(Real)
 
 # AD implementations
-function jacobian(
+function _jacobian(
     b::Union{<:ADBijector{<:ForwardDiffAD}, Inversed{<:ADBijector{<:ForwardDiffAD}}},
     x::Real
 )
-    return ForwardDiff.derivative(b, x)
+    return derivative(b, x)
 end
-function jacobian(
+function _jacobian(
     b::Union{<:ADBijector{<:ForwardDiffAD}, Inversed{<:ADBijector{<:ForwardDiffAD}}},
     x::AbstractVector{<:Real}
 )
-    return ForwardDiff.jacobian(b, x)
+    return jacobian(b, x)
+end
+
 end

--- a/src/compat/tracker.jl
+++ b/src/compat/tracker.jl
@@ -1,51 +1,51 @@
-using .Bijectors
-import Tracker
+module TrackerCompat
 
-using .Bijectors: TrackerAD
+using ..Bijectors: ADBijector, TrackerAD, Inversed, Stacked
+import ..Bijectors: _eps, _jacobian, _logabsdetjac_shift, _logabsdetjac_scale
 
-using Tracker: TrackedReal, TrackedVector, TrackedMatrix, TrackedArray,
-    track, @grad, data
-
-import .Bijectors: _eps, jacobian, logabsdetjac, _logabsdetjac_shift,
-    _logabsdetjac_scale
+using ..Tracker: TrackedReal, TrackedVector, TrackedMatrix, TrackedArray,
+        track, data, gradient, param, collectmemaybe
+# we do not use the `@grad` macro but instead implement `_forward`
+# since `@grad` calls `Tracker._forward` whereas we need `..Tracker._forward`
+import ..Tracker: _forward
 
 _eps(::Type{<:TrackedReal{T}}) where {T} = eps(T)
 
 # AD implementations
-function jacobian(
+function _jacobian(
     b::Union{<:ADBijector{<:TrackerAD}, Inversed{<:ADBijector{<:TrackerAD}}},
     x::Real
 )
-    return data(Tracker.gradient(b, x)[1])
+    return data(gradient(b, x)[1])
 end
-function jacobian(
+function _jacobian(
     b::Union{<:ADBijector{<:TrackerAD}, Inversed{<:ADBijector{<:TrackerAD}}},
     x::AbstractVector{<:Real}
 )
     # We extract `data` so that we don't return a `Tracked` type
-    return data(Tracker.jacobian(b, x))
+    return data(jacobian(b, x))
 end
 
 # implementations for Shift bijector
 function _logabsdetjac_shift(a::TrackedReal, x::Real, ::Val{0})
-    return Tracker.param(_logabsdetjac_shift(data(a), data(x), Val(0)))
+    return param(_logabsdetjac_shift(data(a), data(x), Val(0)))
 end
 function _logabsdetjac_shift(a::TrackedReal, x::AbstractVector{<:Real}, ::Val{0})
-    return Tracker.param(_logabsdetjac_shift(data(a), data(x), Val(0)))
+    return param(_logabsdetjac_shift(data(a), data(x), Val(0)))
 end
 function _logabsdetjac_shift(
     a::Union{TrackedReal, TrackedVector{<:Real}},
     x::AbstractVector{<:Real},
     ::Val{1}
 )
-    return Tracker.param(_logabsdetjac_shift(data(a), data(x), Val(1)))
+    return param(_logabsdetjac_shift(data(a), data(x), Val(1)))
 end
 function _logabsdetjac_shift(
     a::Union{TrackedReal, TrackedVector{<:Real}},
     x::AbstractMatrix{<:Real},
     ::Val{1}
 )
-    return Tracker.param(_logabsdetjac_shift(data(a), data(x), Val(1)))
+    return param(_logabsdetjac_shift(data(a), data(x), Val(1)))
 end
 
 # implementations for Scale bijector
@@ -53,14 +53,14 @@ end
 function _logabsdetjac_scale(a::TrackedReal, x::Real, ::Val{0})
     return track(_logabsdetjac_scale, a, data(x), Val(0))
 end
-@grad function _logabsdetjac_scale(a::Real, x::Real, ::Val{0})
+function _forward(::typeof(_logabsdetjac_scale), a::Real, x::Real, ::Val{0})
     return _logabsdetjac_scale(data(a), data(x), Val(0)), Δ -> (inv(data(a)) .* Δ, nothing, nothing)
 end
 # Need to treat `AbstractVector` and `AbstractMatrix` separately due to ambiguity errors
 function _logabsdetjac_scale(a::TrackedReal, x::AbstractVector, ::Val{0})
     return track(_logabsdetjac_scale, a, data(x), Val(0))
 end
-@grad function _logabsdetjac_scale(a::Real, x::AbstractVector, ::Val{0})
+function _forward(::typeof(_logabsdetjac_scale), a::Real, x::AbstractVector, ::Val{0})
     da = data(a)
     J = fill(inv.(da), length(x))
     return _logabsdetjac_scale(da, data(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
@@ -68,7 +68,7 @@ end
 function _logabsdetjac_scale(a::TrackedReal, x::AbstractMatrix, ::Val{0})
     return track(_logabsdetjac_scale, a, data(x), Val(0))
 end
-@grad function _logabsdetjac_scale(a::Real, x::AbstractMatrix, ::Val{0})
+function _forward(::typeof(_logabsdetjac_scale), a::Real, x::AbstractMatrix, ::Val{0})
     da = data(a)
     J = fill(size(x, 1) / da, size(x, 2))
     return _logabsdetjac_scale(da, data(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
@@ -77,7 +77,7 @@ end
 function _logabsdetjac_scale(a::TrackedVector, x::AbstractVector, ::Val{1})
     return track(_logabsdetjac_scale, a, data(x), Val(1))
 end
-@grad function _logabsdetjac_scale(a::TrackedVector, x::AbstractVector, ::Val{1})
+function _forward(::typeof(_logabsdetjac_scale), a::TrackedVector, x::AbstractVector, ::Val{1})
     # ∂ᵢ (∑ⱼ log|aⱼ|) = ∑ⱼ δᵢⱼ ∂ᵢ log|aⱼ|
     #                 = ∂ᵢ log |aᵢ|
     #                 = (1 / aᵢ) ∂ᵢ aᵢ
@@ -89,7 +89,7 @@ end
 function _logabsdetjac_scale(a::TrackedVector, x::AbstractMatrix, ::Val{1})
     return track(_logabsdetjac_scale, a, data(x), Val(1))
 end
-@grad function _logabsdetjac_scale(a::TrackedVector, x::AbstractMatrix, ::Val{1})
+function _forward(::typeof(_logabsdetjac_scale), a::TrackedVector, x::AbstractMatrix, ::Val{1})
     da = data(a)
     Jᵀ = repeat(inv.(da), 1, size(x, 2))
     return _logabsdetjac_scale(da, data(x), Val(1)), Δ -> (Jᵀ * Δ, nothing, nothing)
@@ -104,10 +104,12 @@ end
 
 # implementations for Stacked bijector
 function logabsdetjac(b::Stacked, x::TrackedMatrix{<:Real})
-    return Tracker.collect([logabsdetjac(b, x[:, i]) for i = 1:size(x, 2)])
+    return collectmemaybe([logabsdetjac(b, x[:, i]) for i = 1:size(x, 2)])
 end
 # TODO: implement custom adjoint since we can exploit block-diagonal nature of `Stacked`
 function (sb::Stacked)(x::TrackedMatrix{<:Real})
     init = reshape(sb(x[:, 1]), :, 1)
-    return Tracker.collect(mapreduce(i -> sb(x[:, i]), hcat, 2:size(x, 2); init = init))
+    return collectmemaybe(mapreduce(i -> sb(x[:, i]), hcat, 2:size(x, 2); init = init))
+end
+
 end


### PR DESCRIPTION
Turing's CI tests show that the optional dependencies on ForwardDiff and Tracker are not correctly implemented. As noted in the [documentation of Requires](https://github.com/MikeInnes/Requires.jl/blob/master/README.md#requiresjl), one has to use `using/import .ForwardDiff` and `using/import .Tracker` in the included files instead of `using/import ForwardDiff` and `using/import Tracker`.

Unfortunately, just adding a dot in front of every occurrence of `ForwardDiff` and `Tracker` does not work since ["relative-import qualifiers are only valid in `using` and `import` statements"](https://docs.julialang.org/en/v1/manual/modules/#Relative-and-absolute-module-paths-1) and hence it is not possible to call `.ForwardDiff.jacobian` and `.Tracker.jacobian` - instead the `jacobian` functions have to be imported! However, this leads to namespace problems since Bijectors, ForwardDiff and Tracker all define their own `jacobian` function.

The PR solves this problem by defining `jacobian(b, x) = _jacobian(b, x)` in Bijectors and implementing separate modules for ForwardDiff and Tracker compatibility in which `_jacobian` is imported from Bijectors and `jacobian` from ForwardDiff and Tracker, respectively.

Moreover, since the convenience macro `Tracker.@grad` [hardcodes a call to `Tracker._forward`](https://github.com/FluxML/Tracker.jl/blob/128c29d46d51e182319bbdbae066dc279bdee2af/src/Tracker.jl#L62) it can't be used and instead `_forward` has to be implemented directly.

Running Turing's tests with this PR shows that indeed the approach in this PR fixes the current implementation.