### PR TITLE
Remove Tracker implementation of Shift bijector

### DIFF
--- a/src/bijectors/shift.jl
+++ b/src/bijectors/shift.jl
@@ -18,7 +18,16 @@ inv(b::Shift{T, N}) where {T, N} = Shift{T, N}(-b.a)
 # FIXME: implement custom adjoint to ensure we don't get tracking
 logabsdetjac(b::Shift{T, N}, x) where {T, N} = _logabsdetjac_shift(b.a, x, Val(N))
 
-_logabsdetjac_shift(a::Real, x::Real, ::Val{0}) = zero(eltype(x))
-_logabsdetjac_shift(a::Real, x::AbstractVector{T}, ::Val{0}) where {T<:Real} = zeros(T, length(x))
-_logabsdetjac_shift(a::T1, x::AbstractVector{T2}, ::Val{1}) where {T1<:Union{Real, AbstractVector}, T2<:Real} = zero(T2)
-_logabsdetjac_shift(a::T1, x::AbstractMatrix{T2}, ::Val{1}) where {T1<:Union{Real, AbstractVector}, T2<:Real} = zeros(T2, size(x, 2))
+_logabsdetjac_shift(a::Real, x::Real, ::Val{0}) = zero(Base.promote_typeof(a, x))
+function _logabsdetjac_shift(a::Real, x::AbstractVector{<:Real}, ::Val{0})
+    T = Base.promote_eltype(a, x)
+    return zeros(T, length(x))
+end
+function _logabsdetjac_shift(a::Union{Real, AbstractVector}, x::AbstractVector{<:Real}, ::Val{1})
+    T = Base.promote_eltype(a, x)
+    return zero(T)
+end
+function _logabsdetjac_shift(a::Union{Real, AbstractVector}, x::AbstractMatrix{<:Real}, ::Val{1})
+    T = Base.promote_eltype(a, x)
+    return zeros(T, size(x, 2))
+end

--- a/src/compat/tracker.jl
+++ b/src/compat/tracker.jl
@@ -18,28 +18,6 @@ function jacobian(
     return Tracker.data(Tracker.jacobian(b, x))
 end
 
-# implementations for Shift bijector
-function _logabsdetjac_shift(a::TrackedReal, x::Real, ::Val{0})
-    return Tracker.param(_logabsdetjac_shift(Tracker.data(a), Tracker.data(x), Val(0)))
-end
-function _logabsdetjac_shift(a::TrackedReal, x::AbstractVector{<:Real}, ::Val{0})
-    return Tracker.param(_logabsdetjac_shift(Tracker.data(a), Tracker.data(x), Val(0)))
-end
-function _logabsdetjac_shift(
-    a::Union{TrackedReal, TrackedVector{<:Real}},
-    x::AbstractVector{<:Real},
-    ::Val{1}
-)
-    return Tracker.param(_logabsdetjac_shift(Tracker.data(a), Tracker.data(x), Val(1)))
-end
-function _logabsdetjac_shift(
-    a::Union{TrackedReal, TrackedVector{<:Real}},
-    x::AbstractMatrix{<:Real},
-    ::Val{1}
-)
-    return Tracker.param(_logabsdetjac_shift(Tracker.data(a), Tracker.data(x), Val(1)))
-end
-
 # implementations for Scale bijector
 # Adjoints for 0-dim and 1-dim `Scale` using `Real`
 function _logabsdetjac_scale(a::TrackedReal, x::Real, ::Val{0})


### PR DESCRIPTION
This PR removes the special implementation of `logabsdetjac` of the Shift bijector for TrackedReal's and TrackedVector's.