### PR TITLE
Making SimplexBijector compatible with Tracker.jl

### DIFF
--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -189,32 +189,7 @@ function link_jacobian(
     x::AbstractVector{T},
     ::Type{Val{proj}} = Val{true}
 ) where {T<:Real, proj}
-    K = length(x)
-    dydxt = similar(x, length(x), length(x))
-    @inbounds dydxt .= 0
-    ϵ = _eps(T)
-    sum_tmp = zero(T)
-
-    @inbounds z = x[1] * (one(T) - 2ϵ) + ϵ # z ∈ [ϵ, 1-ϵ]
-    @inbounds dydxt[1,1] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)
-    @inbounds @simd for k in 2:(K - 1)
-        sum_tmp += x[k - 1]
-        # z ∈ [ϵ, 1-ϵ]
-        # x[k] = 0 && sum_tmp = 1 -> z ≈ 1
-        z = (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
-        dydxt[k,k] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
-        for i in 1:k-1
-            dydxt[i,k] = (1/z + 1/(1-z)) * (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)^2
-        end
-    end
-    @inbounds sum_tmp += x[K - 1]
-    @inbounds if !proj
-        @simd for i in 1:K
-            dydxt[i,K] = -1
-        end
-    end
-
-    return UpperTriangular(dydxt)'
+    return jacobian(SimplexBijector{proj}(), x)
 end
 
 function invlink(
@@ -230,51 +205,7 @@ function invlink_jacobian(
     y::AbstractVector{T},
     ::Type{Val{proj}} = Val{true}
 ) where {T<:Real, proj}
-    K = length(y)
-    dxdy = similar(y, length(y), length(y))
-    @inbounds dxdy .= 0
-
-    ϵ = _eps(T)
-    @inbounds z = StatsFuns.logistic(y[1] - log(T(K - 1)))
-    unclamped_x = (z - ϵ) / (one(T) - 2ϵ)
-    clamped_x = _clamp(unclamped_x, d)
-    @inbounds if unclamped_x == clamped_x
-        dxdy[1,1] = z * (1 - z) / (one(T) - 2ϵ)
-    end
-    sum_tmp = zero(T)
-    @inbounds for k = 2:(K - 1)
-        z = StatsFuns.logistic(y[k] - log(T(K - k)))
-        sum_tmp += clamped_x
-        unclamped_x = ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ
-        clamped_x = _clamp(unclamped_x, d)
-        if unclamped_x == clamped_x
-            dxdy[k,k] = z * (1 - z) * ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ)
-            for i in 1:k-1
-                for j in i:k-1
-                    dxdy[k,i] += -dxdy[j,i] * z / (one(T) - 2ϵ)
-                end
-            end
-        end
-    end
-    @inbounds sum_tmp += clamped_x
-    @inbounds if proj
-    	unclamped_x = one(T) - sum_tmp
-        clamped_x = _clamp(unclamped_x, d)
-    else
-    	unclamped_x = one(T) - sum_tmp - y[K]
-        clamped_x = _clamp(unclamped_x, d)
-        if unclamped_x == clamped_x
-            dxdy[K,K] = -1
-        end
-    end
-    @inbounds if unclamped_x == clamped_x
-        for i in 1:K-1
-            @simd for j in i:K-1
-                dxdy[K,i] += -dxdy[j,i]
-            end
-        end
-    end
-    return LowerTriangular(dxdy)
+    return jacobian(inv(SimplexBijector{proj}()), y)
 end
 
 function logpdf_with_trans(

--- a/src/compat/tracker.jl
+++ b/src/compat/tracker.jl
@@ -103,3 +103,22 @@ function (sb::Stacked)(x::TrackedMatrix{<:Real})
     init = reshape(sb(x[:, 1]), :, 1)
     return Tracker.collect(mapreduce(i -> sb(x[:, i]), hcat, 2:size(x, 2); init = init))
 end
+
+# Stuff
+function _simplex_bijector(b::SimplexBijector{proj}, x::TrackedVector{T}) where {proj, T}
+    Tracker.track(_simplex_bijector, b, x)
+end
+
+Tracker.@grad function _simplex_bijector(b::SimplexBijector{proj}, x::AbstractVector{T}) where {proj, T}
+    x_untracked = Tracker.data(x)
+    return _simplex_bijector(b, x_untracked), Δ -> (nothing, jacobian(b, x_untracked)' * Δ)
+end
+
+function _simplex_bijector_inv(ib::Inversed{<:SimplexBijector{proj}}, y::TrackedVector{T}) where {proj, T}
+    Tracker.track(_simplex_bijector_inv, ib, y)
+end
+
+Tracker.@grad function _simplex_bijector_inv(ib::Inversed{<:SimplexBijector{proj}}, y::AbstractVector{T}) where {proj, T}
+    y_untracked = Tracker.data(y)
+    return _simplex_bijector_inv(ib, y_untracked), Δ -> (nothing, jacobian(ib, y_untracked)' * Δ)
+end


### PR DESCRIPTION
This PR fixes the issues with Tracker.jl and SimplexBijector, using the by-hand implementations of the jacobian of `SimplexBijector` and its inverse (thanks to @mohamed82008!).