### PR TITLE
Fixed forward pass of Truncated for vector input

### DIFF
--- a/src/bijectors/truncated.jl
+++ b/src/bijectors/truncated.jl
@@ -26,9 +26,9 @@ function (b::TruncatedBijector)(x::AbstractVector{<:Real})
     if lowerbounded && upperbounded
         return @. StatsFuns.logit((x - a) / (b - a))
     elseif lowerbounded
-        return log.(x - a)
+        return @. log(x - a)
     elseif upperbounded
-        return log.(b - x)
+        return @. log(b - x)
     else
         return x
     end


### PR DESCRIPTION
The following fails:

``` julia
julia> using Bijectors

julia> b = Bijectors.TruncatedBijector(0.0, Inf)
Bijectors.TruncatedBijector{Float64}(0.0, Inf)

julia> b(ones(2))
ERROR: MethodError: no method matching -(::Array{Float64,1}, ::Float64)
Closest candidates are:
  -(::Float64, ::Float64) at float.jl:403
  -(::Complex{Bool}, ::Real) at complex.jl:303
  -(::Missing, ::Number) at missing.jl:115
  ...
Stacktrace:
 [1] (::Bijectors.TruncatedBijector{Float64})(::Array{Float64,1}) at /home/tor/.julia/packages/Bijectors/4lqvI/src/bijectors/truncated.jl:29
 [2] top-level scope at REPL[29]:1

```

which is due to a missing fusing-operation. This PR fixes this.