### PR TITLE
Fix import of ReverseDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/compat/reversediff.jl
+++ b/src/compat/reversediff.jl
@@ -1,8 +1,9 @@
+using .ReverseDiff: record_mul, SpecialInstruction
+import .ReverseDiff
+
 const RTR = ReverseDiff.TrackedReal
 const RTV = ReverseDiff.TrackedVector
 const RTM = ReverseDiff.TrackedMatrix
-using ReverseDiff: record_mul
-using ReverseDiff: SpecialInstruction
 
 _eps(::Type{<:RTR{T}}) where {T} = _eps(T)
 


### PR DESCRIPTION
This PR fixes errors such as
```julia
┌ Warning: Error requiring ReverseDiff from Bijectors:
│ LoadError: ArgumentError: Package Bijectors does not have ReverseDiff in its dependencies:
│ - If you have Bijectors checked out for development and have
│   added ReverseDiff as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Bijectors
```
when loading, e.g., Turing.