### PR TITLE
Distributions.product_distribution - Bijectors.link & Bijectors.invlink transforms

### DIFF
--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -54,6 +54,8 @@ bijector(d::BoundedDistribution) = bijector_bounded(d)
 const LowerboundedDistribution = Union{Pareto, Levy}
 bijector(d::LowerboundedDistribution) = bijector_lowerbounded(d)
 
+bijector(d::Distributions.Product) = Stacked(bijector.(d.v))
+
 
 ##############################
 # Distributions.jl interface #


### PR DESCRIPTION
(Issue opened by @paschermayr)

Hi guys, 

I need to work with with a product distribution of uniforms . When transforming and inverse transforming the random variables, I dont get any error messages from Bijectors, but transforms and inverse transforms do not seem to work correctly. Minimum working example:

```
using Distributions, Bijectors #Bijectors v0.6.3, Distributions v0.22.6
x = [.5, .5]
distr = Distributions.product_distribution( [Uniform(-1,1) for i in 1:2] )
y = Bijectors.link(distr, x) #still [.5, .5]
Bijectors.invlink(distr, [150., 150]) #still [150., 150] ~ not in support
```

Apologies if I oversee something trivial.

EDIT: I tried to do something clever which was automatically creating a PR from an issue and it seems to have just converted the issue into a PR. _Not_ my intention and won't do this in the future, that's for sure.