### PR TITLE
Making it a bit easier to override default `link` etc. using `bijector`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,10 +19,10 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
 ArgCheck = "1, 2.0"
-Combinatorics = "0.7"
+Combinatorics = "1.0"
 Compat = "3.0"
 Distributions = "0.21.11, 0.22, 0.23"
-DistributionsAD = "0.4.6"
+DistributionsAD = "0.5.0"
 ForwardDiff = "0.10.3"
 MappedArrays = "0.2.2"
 NNlib = "0.6"

--- a/README.md
+++ b/README.md
@@ -536,13 +536,13 @@ struct Logit{T<:Real} <: Bijector{0}
 end
 
 (b::Logit)(x::Real) = logit((x - b.a) / (b.b - b.a))
-(b::Logit)(x) = mapvcat(b, x)
+(b::Logit)(x) = map(b, x)
 # `orig` contains the `Bijector` which was inverted
 (ib::Inverse{<:Logit})(y::Real) = (ib.orig.b - ib.orig.a) * logistic(y) + ib.orig.a
-(ib::Inverse{<:Logit})(y) = mapvcat(ib, y)
+(ib::Inverse{<:Logit})(y) = map(ib, y)
 
 logabsdetjac(b::Logit, x::Real) = - log((x - b.a) * (b.b - x) / (b.b - b.a))
-logabsdetjac(b::Logit, x) = mapvcat(logabsdetjac, x)
+logabsdetjac(b::Logit, x) = map(logabsdetjac, x)
 ```
 
 (Batch computation is not fully supported by all bijectors yet (see issue #35), but is actively worked on. In the particular case of `Logit` there's only one thing that makes sense, which is elementwise application. Therefore we've added `@.` to the implementation above, thus this works for any `AbstractArray{<:Real}`.)
@@ -650,8 +650,8 @@ true
 We can also use Tracker.jl for the AD, rather than ForwardDiff.jl:
 
 ```julia
-julia> Bijectors.setadbackend(:reverse_diff)
-:reverse_diff
+julia> Bijectors.setadbackend(:reversediff)
+:reversediff
 
 julia> b_ad = ADLogit(0.0, 1.0)
 ADLogit{Float64,Bijectors.TrackerAD}(0.0, 1.0)

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -257,7 +257,7 @@ end
 # Positive definite #
 #####################
 
-const PDMatDistribution = Union{InverseWishart, Wishart}
+const PDMatDistribution = Union{InverseWishart, Wishart, MatrixBeta}
 
 # link(d::PDMatDistribution, X::AbstractMatrix{<:Real}) = PDBijector()(X)
 # invlink(d::PDMatDistribution, Y::AbstractMatrix{<:Real}) = inv(PDBijector())(Y)

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -1,5 +1,33 @@
 module Bijectors
 
+#=
+  NOTE: Codes below are adapted from
+  https://github.com/brian-j-smith/Mamba.jl/blob/master/src/distributions/transformdistribution.jl
+  The Mamba.jl package is licensed under the MIT License:
+  > Copyright (c) 2014: Brian J Smith and other contributors:
+  >
+  > https://github.com/brian-j-smith/Mamba.jl/contributors
+  >
+  > Permission is hereby granted, free of charge, to any person obtaining
+  > a copy of this software and associated documentation files (the
+  > "Software"), to deal in the Software without restriction, including
+  > without limitation the rights to use, copy, modify, merge, publish,
+  > distribute, sublicense, and/or sell copies of the Software, and to
+  > permit persons to whom the Software is furnished to do so, subject to
+  > the following conditions:
+  >
+  > The above copyright notice and this permission notice shall be
+  > included in all copies or substantial portions of the Software.
+  >
+  > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  > IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  > CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  > TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  > SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=#
+
 using Reexport, Requires
 @reexport using Distributions
 using StatsFuns
@@ -33,7 +61,6 @@ export  TransformDistribution,
         DistributionBijector,
         bijector,
         transformed,
-        TransformedDistribution,
         UnivariateTransformed,
         MultivariateTransformed,
         logpdf_with_jac,
@@ -52,18 +79,16 @@ _debug(str) = @debug str
 _eps(::Type{T}) where {T} = T(eps(T))
 _eps(::Type{Real}) = eps(Float64)
 _eps(::Type{<:Integer}) = eps(Float64)
-_istracked(::Any) = false
+
+function _clamp(x, a, b)
+    T = promote_type(typeof(x), typeof(a), typeof(b))
+    ϵ = _eps(T)
+    clamped_x = ifelse(x < a, convert(T, a), ifelse(x > b, convert(T, b), x))
+    DEBUG && _debug("x = $x, bounds = $((a, b)), clamped_x = $clamped_x")
+    return clamped_x
+end
 
 function mapvcat(f, args...)
-    out = map(f, args...)
-    if _istracked(out)
-        init = vcat(out[1])
-        return reshape(reduce(vcat, drop(out, 1); init = init), size(out))
-    else
-        return out
-    end
-end
-function mapvcat2(f, args...)
     out = map(f, args...)
     init = vcat(out[1])
     return reshape(reduce(vcat, drop(out, 1); init = init), size(out))
@@ -84,127 +109,125 @@ function eachcolmaphcat(f, x)
     init = reshape(out[1], :, 1)
     return reduce(hcat, drop(out, 1); init = init)
 end
-function _sum(f, args...)
-    init = f(first.(args)...)
-    return mapreduce(f, +, drop.(args, 1)...; init = init)
-end
-function _sumeachcol(f, x1, x2)
+function sumeachcol(f, x1, x2)
     # Using a view below for x1 breaks Tracker
     return sum(f(x1[:,i], x2[i]) for i in 1:size(x1, 2))
 end
 
-# Discrete distributions
+# Distributions
 
-function logpdf_with_trans(d::DiscreteUnivariateDistribution, x::Integer, transform::Bool)
-    return logpdf(d, x)
-end
-function logpdf_with_trans(
-    d::DiscreteUnivariateDistribution,
-    x::AbstractArray{<:Real},
-    transform::Bool,
-)
-    return mapvcat(x) do x
-        logpdf(d, x)
+link(d::Distribution, x) = bijector(d)(x)
+invlink(d::Distribution, y) = inv(bijector(d))(y)
+function logpdf_with_trans(d::Distribution, x, transform::Bool)
+    if transform
+        return logpdf(d, x) - logabsdetjac(bijector(d), x)
+    else
+        return logpdf(d, x)
     end
 end
-function logpdf_with_trans(
-    d::DiscreteMultivariateDistribution,
-    x::AbstractVecOrMat{<:Real},
-    transform::Bool,
-)
-    return logpdf(d, x)
-end
 
-#=
-  NOTE: Codes below are adapted from
-  https://github.com/brian-j-smith/Mamba.jl/blob/master/src/distributions/transformdistribution.jl
-  The Mamba.jl package is licensed under the MIT License:
-  > Copyright (c) 2014: Brian J Smith and other contributors:
-  >
-  > https://github.com/brian-j-smith/Mamba.jl/contributors
-  >
-  > Permission is hereby granted, free of charge, to any person obtaining
-  > a copy of this software and associated documentation files (the
-  > "Software"), to deal in the Software without restriction, including
-  > without limitation the rights to use, copy, modify, merge, publish,
-  > distribute, sublicense, and/or sell copies of the Software, and to
-  > permit persons to whom the Software is furnished to do so, subject to
-  > the following conditions:
-  >
-  > The above copyright notice and this permission notice shall be
-  > included in all copies or substantial portions of the Software.
-  >
-  > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-  > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-  > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-  > IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-  > CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-  > TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-  > SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=#
+## Univariate
 
-#############
-# a ≦ x ≦ b #
-#############
-
-const TransformDistribution{T<:ContinuousUnivariateDistribution} = Union{T, Truncated{T}}
-@inline function _clamp(x::T, dist::TransformDistribution) where {T <: Real}
-    ϵ = _eps(T)
-    bounds = (minimum(dist) + ϵ, maximum(dist) - ϵ)
-    clamped_x = ifelse(x < bounds[1], bounds[1], ifelse(x > bounds[2], bounds[2], x))
-    DEBUG && _debug("x = $x, bounds = $bounds, clamped_x = $clamped_x")
-    return clamped_x
-end
-
-link(d::TransformDistribution, x::Real) = _link(d, _clamp(x, d))
-_link(d::TransformDistribution, x::Real) = bijector(d)(x)
-
-invlink(d::TransformDistribution, y::Real) = _clamp(_invlink(d, y), d)
-_invlink(d::TransformDistribution, y::Real) = inv(bijector(d))(y)
-
-function logpdf_with_trans(
-    d::TransformDistribution,
-    x::Real,
-    transform::Bool,
-)
-    return _logpdf_with_trans(d, x, transform)
-end
-function logpdf_with_trans(
-    d::TransformDistribution,
-    x::AbstractArray{<:Real},
-    transform::Bool,
-)
-    return mapvcat(x -> _logpdf_with_trans(d, x, transform), x)
-end
-function _logpdf_with_trans(d::TransformDistribution, x::Real, transform::Bool)
-    return logpdf(d, x) - transform * logabsdetjac(bijector(d), x)
-end
-
-#########
-# 0 < x #
-#########
-
+const TransformDistribution = Union{
+    T,
+    Truncated{T},
+} where T <: ContinuousUnivariateDistribution
 const PositiveDistribution = Union{
     BetaPrime, Chi, Chisq, Erlang, Exponential, FDist, Frechet, Gamma, InverseGamma,
     InverseGaussian, Kolmogorov, LogNormal, NoncentralChisq, NoncentralF, Rayleigh, Weibull,
 }
-
-#############
-# 0 < x < 1 #
-#############
-
 const UnitDistribution = Union{Beta, KSOneSided, NoncentralBeta}
+
+function logpdf_with_trans(d::UnivariateDistribution, x::AbstractArray{<:Real}, trans::Bool)
+    if toflatten(d)
+        f, args = flatten(d, trans)
+        return f.(args..., x)
+    else
+        return map(x) do x
+            logpdf_with_trans(d, x, trans)
+        end
+    end
+end
+
+function logpdf_with_trans(d::DiscreteUnivariateDistribution, x::Integer, transform::Bool)
+    return logpdf(d, x)
+end
+
+## Multivariate
+
+function logpdf_with_trans(
+    dist::Distributions.Product,
+    x::AbstractVector{<:Real},
+    istrans::Bool,
+)
+    return sum(maporbroadcast(dist.v, x) do d, x
+        logpdf_with_trans(d, x, istrans)
+    end)
+end
+function logpdf_with_trans(
+    dist::Distributions.Product,
+    x::AbstractMatrix{<:Real},
+    istrans::Bool,
+)
+    return map(eachcol(x)) do x
+        logpdf_with_trans(dist, x, istrans)
+    end
+end
+
+function link(
+    dist::Distributions.Product,
+    x::AbstractVector{<:Real},
+)
+    return maporbroadcast(link, dist.v, x)
+end
+function link(
+    dist::Distributions.Product,
+    x::AbstractMatrix{<:Real},
+)
+    return map(eachcol(x)) do x
+        link(dist, x)
+    end
+end
+
+function invlink(
+    dist::Distributions.Product,
+    x::AbstractVector{<:Real},
+)
+    return maporbroadcast(invlink, dist.v, x)
+end
+function invlink(
+    dist::Distributions.Product,
+    x::AbstractMatrix{<:Real},
+)
+    return map(eachcol(x)) do x
+        invlink(dist, x)
+    end
+end
+
+function maporbroadcast(f, dists::AbstractArray, x::AbstractArray)
+    # Broadcasting here breaks Tracker for some reason
+    return map(f, dists, x)
+end
+function maporbroadcast(f, dists::AbstractVector, x::AbstractMatrix)
+    return map(x -> sum(maporbroadcast(f, dists, x)), eachcol(x))
+end
+
+const SimplexDistribution = Union{Dirichlet}
+
+function logpdf_with_trans(
+    d::DiscreteMultivariateDistribution,
+    x::AbstractVecOrMat{<:Real},
+    ::Bool,
+)
+    return logpdf(d, x)
+end
 
 ###########
 # ∑xᵢ = 1 #
 ###########
 
-const SimplexDistribution = Union{Dirichlet}
-
-_clamp(x, ::SimplexDistribution) = _clamp(x, SimplexBijector())
-
 function link(
-    d::SimplexDistribution,
+    d::Dirichlet,
     x::AbstractVecOrMat{<:Real},
     proj::Bool = true,
 )
@@ -212,7 +235,7 @@ function link(
 end
 
 function link_jacobian(
-    d::SimplexDistribution,
+    d::Dirichlet,
     x::AbstractVector{T},
     proj::Bool = true,
 ) where {T<:Real}
@@ -220,7 +243,7 @@ function link_jacobian(
 end
 
 function invlink(
-    d::SimplexDistribution,
+    d::Dirichlet,
     y::AbstractVecOrMat{<:Real},
     proj::Bool = true
 )
@@ -228,7 +251,7 @@ function invlink(
 end
 
 function invlink_jacobian(
-    d::SimplexDistribution,
+    d::Dirichlet,
     y::AbstractVector{T},
     proj::Bool = true
 ) where {T<:Real}
@@ -236,10 +259,13 @@ function invlink_jacobian(
 end
 
 function logpdf_with_trans(
-    d::SimplexDistribution,
+    d::Dirichlet,
     x::AbstractVecOrMat{<:Real},
     transform::Bool,
 )
+    return dirichlet_logpdf_with_trans(d, x, transform)
+end
+function dirichlet_logpdf_with_trans(d, x, transform)
     ϵ = _eps(eltype(x))
     lp = logpdf(d, x .+ ϵ)
     if transform
@@ -248,10 +274,7 @@ function logpdf_with_trans(
     return lp
 end
 
-# REVIEW: why do we put this piece of code here?
-function logpdf_with_trans(d::Categorical, x::Int)
-    return d.p[x] > 0.0 && insupport(d, x) ? log(d.p[x]) : eltype(d.p)(-Inf)
-end
+## Matrix
 
 #####################
 # Positive definite #
@@ -259,22 +282,23 @@ end
 
 const PDMatDistribution = Union{InverseWishart, Wishart}
 
-
-function logpdf_with_trans(
-    d::PDMatDistribution,
-    X::AbstractMatrix{<:Real},
-    transform::Bool
-)
-    _logpdf_with_trans_pd(d, X, transform)
-end
 function logpdf_with_trans(
     d::PDMatDistribution,
     X::AbstractArray{<:AbstractMatrix{<:Real}},
-    transform::Bool
+    transform::Bool,
 )
-    mapvcat(x -> _logpdf_with_trans_pd(d, x, transform), X)
+    return map(X) do x
+        logpdf_with_trans(d, x, transform)
+    end
 end
-function _logpdf_with_trans_pd(
+function logpdf_with_trans(
+    d::PDMatDistribution,
+    X::AbstractMatrix{<:Real},
+    transform::Bool,
+)
+    pd_logpdf_with_trans(d, X, transform)
+end
+function pd_logpdf_with_trans(
     d,
     X::AbstractMatrix{<:Real},
     transform::Bool,
@@ -300,57 +324,19 @@ function getlogp(d::InverseWishart, Xcf, X)
     return -0.5 * ((d.df + dim(d) + 1) * logdet(Xcf) + tr(Xcf \ Ψ)) - d.c0
 end
 
-############################################
-# Defaults (assume identity link function) #
-############################################
-link(d::Distribution, x) = bijector(d)(x)
-invlink(d::Distribution, y) = inv(bijector(d))(y)
-function logpdf_with_trans(d::Distribution, x, transform::Bool)
-    if transform
-        return logpdf(d, x) - logabsdetjac(bijector(d), x)
-    else
-        return logpdf(d, x)
-    end
-end
-
-# UnivariateDistributions
-using Distributions: UnivariateDistribution
-
-link(d::UnivariateDistribution, x::AbstractArray{<:Real}) = mapvcat(x) do x
-    link(d, x)
-end
-
-invlink(d::UnivariateDistribution, y::AbstractArray{<:Real}) = mapvcat(y) do y
-    invlink(d, y)
-end
-
-function logpdf_with_trans(
-    d::UnivariateDistribution,
-    x::AbstractArray{<:Real},
-    transform::Bool,
-)
-    return mapvcat(x) do x
-        logpdf_with_trans(d, x, transform)
-    end
-end
-
-# MatrixDistributions
-using Distributions: MatrixDistribution
-
-link(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}}) = mapvcat(X) do x
-    link(d, x)
-end
-
-function invlink(d::MatrixDistribution, Y::AbstractArray{<:AbstractMatrix{<:Real}})
-    return mapvcat(Y) do y
-        invlink(d, y)
-    end
-end
-
+include("flatten.jl")
 include("interface.jl")
 
 # optional dependencies
 function __init__()
+    @require LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02" begin
+        function maporbroadcast(f, dists::LazyArrays.BroadcastArray, x::AbstractArray)
+            return copy(f.(dists, x))
+        end
+        function maporbroadcast(f, dists::LazyArrays.BroadcastVector, x::AbstractMatrix)
+            return vec(sum(copy(f.(dists, x)), dims = 1))
+        end
+    end
     @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" include("compat/forwarddiff.jl")
     @require Tracker="9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include("compat/tracker.jl")
     @require Zygote="e88e6eb3-aa80-5325-afca-941959d7151f" include("compat/zygote.jl")

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -388,27 +388,27 @@ end
 ############################################
 # Defaults (assume identity link function) #
 ############################################
+link(d::Distribution, x) = bijector(d)(x)
+invlink(d::Distribution, y) = inv(bijector(d))(y)
+function logpdf_with_trans(d::Distribution, x, transform::Bool)
+    if transform
+        return logpdf(d, x) - logabsdetjac(bijector(d), x)
+    else
+        return logpdf(d, x)
+    end
+end
 
 # UnivariateDistributions
 using Distributions: UnivariateDistribution
 
-link(d::UnivariateDistribution, x::Real) = x
 link(d::UnivariateDistribution, x::AbstractArray{<:Real}) = mapvcat(x) do x
     link(d, x)
 end
 
-invlink(d::UnivariateDistribution, y::Real) = y
 invlink(d::UnivariateDistribution, y::AbstractArray{<:Real}) = mapvcat(y) do y
     invlink(d, y)
 end
 
-function logpdf_with_trans(
-    d::UnivariateDistribution,
-    x::Real,
-    transform::Bool,
-)
-    return _logpdf_with_trans(d, x, transform)
-end
 function logpdf_with_trans(
     d::UnivariateDistribution,
     x::AbstractArray{<:Real},
@@ -419,38 +419,17 @@ function logpdf_with_trans(
     end
 end
 
-# MultivariateDistributions
-using Distributions: MultivariateDistribution
-
-link(d::MultivariateDistribution, x::AbstractVecOrMat{<:Real}) = copy(x)
-
-invlink(d::MultivariateDistribution, y::AbstractVecOrMat{<:Real}) = copy(y)
-
-function logpdf_with_trans(d::MultivariateDistribution, x::AbstractVecOrMat{<:Real}, ::Bool)
-    return logpdf(d, x)
-end
-
 # MatrixDistributions
 using Distributions: MatrixDistribution
 
-link(d::MatrixDistribution, X::AbstractMatrix{<:Real}) = copy(X)
 link(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}}) = mapvcat(X) do x
     link(d, x)
 end
 
-invlink(d::MatrixDistribution, Y::AbstractMatrix{<:Real}) = copy(Y)
 function invlink(d::MatrixDistribution, Y::AbstractArray{<:AbstractMatrix{<:Real}})
     return mapvcat(Y) do y
         invlink(d, y)
     end
-end
-
-function logpdf_with_trans(
-    d::MatrixDistribution,
-    X::Union{AbstractMatrix{<:Real}, AbstractArray{<:AbstractMatrix{<:Real}}},
-    ::Bool,
-)
-    return logpdf(d, X)
 end
 
 include("interface.jl")

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -174,33 +174,39 @@ function logpdf_with_trans(
     end
 end
 
+link(dist::Distributions.Product{Discrete}, x::AbstractVector{<:Real}) = copy(x)
 function link(
-    dist::Distributions.Product,
+    dist::Distributions.Product{Continuous},
     x::AbstractVector{<:Real},
 )
     return maporbroadcast(link, dist.v, x)
 end
+
+link(dist::Distributions.Product{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
-    dist::Distributions.Product,
+    dist::Distributions.Product{Continuous},
     x::AbstractMatrix{<:Real},
 )
-    return map(eachcol(x)) do x
-        link(dist, x)
+    return eachcolmaphcat(x) do c
+        link(dist, c)
     end
 end
 
+invlink(dist::Distributions.Product{Discrete}, x::AbstractVector{<:Real}) = copy(x)
 function invlink(
-    dist::Distributions.Product,
+    dist::Distributions.Product{Continuous},
     x::AbstractVector{<:Real},
 )
     return maporbroadcast(invlink, dist.v, x)
 end
+
+invlink(dist::Distributions.Product{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function invlink(
-    dist::Distributions.Product,
+    dist::Distributions.Product{Continuous},
     x::AbstractMatrix{<:Real},
 )
-    return map(eachcol(x)) do x
-        invlink(dist, x)
+    return eachcolmaphcat(x) do c
+        invlink(dist, c)
     end
 end
 

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -257,10 +257,8 @@ end
 # Positive definite #
 #####################
 
-const PDMatDistribution = Union{InverseWishart, Wishart, MatrixBeta}
+const PDMatDistribution = Union{InverseWishart, Wishart}
 
-# link(d::PDMatDistribution, X::AbstractMatrix{<:Real}) = PDBijector()(X)
-# invlink(d::PDMatDistribution, Y::AbstractMatrix{<:Real}) = inv(PDBijector())(Y)
 
 function logpdf_with_trans(
     d::PDMatDistribution,

--- a/src/bijectors/distribution_bijector.jl
+++ b/src/bijectors/distribution_bijector.jl
@@ -1,4 +1,3 @@
-# TODO: Deprecate?
 """
     DistributionBijector(d::Distribution)
     DistributionBijector{<:ADBackend, D}(d::Distribution)
@@ -24,3 +23,10 @@ end
 # Simply uses `link` and `invlink` as transforms with AD to get jacobian
 (b::DistributionBijector)(x) = link(b.dist, x)
 (ib::Inverse{<:DistributionBijector})(y) = invlink(ib.orig.dist, y)
+
+function logabsdetjac(
+    b::DistributionBijector{<:Any, <:Product},
+    x::AbstractVector{<:Real},
+)
+    return sum(logabsdetjac.(bijector.(b.dist.v), x))
+end

--- a/src/bijectors/logit.jl
+++ b/src/bijectors/logit.jl
@@ -8,13 +8,14 @@ struct Logit{T<:Real} <: Bijector{0}
     b::T
 end
 
-(b::Logit)(x::Real) = logit((x - b.a) / (b.b - b.a))
-(b::Logit)(x) = mapvcat(b, x)
+(b::Logit)(x::Real) = _logit(x, b.a, b.b)
+(b::Logit)(x) = _logit.(x, b.a, b.b)
+_logit(x, a, b) = logit((x - a) / (b - a))
 
-(ib::Inverse{<:Logit})(y::Real) = (ib.orig.b - ib.orig.a) * logistic(y) + ib.orig.a
-(ib::Inverse{<:Logit})(y) = mapvcat(ib, y)
+(ib::Inverse{<:Logit})(y::Real) = _ilogit(y, ib.orig.a, ib.orig.b)
+(ib::Inverse{<:Logit})(y) = _ilogit.(y, ib.orig.a, ib.orig.b)
+_ilogit(y, a, b) = (b - a) * logistic(y) + a
 
-logabsdetjac(b::Logit, x::Real) = -log((x - b.a) * (b.b - x) / (b.b - b.a))
-logabsdetjac(b::Logit, x) = mapvcat(x) do x
-    logabsdetjac(b, x)
-end
+logabsdetjac(b::Logit, x::Real) = logit_logabsdetjac(x, b.a, b.b)
+logabsdetjac(b::Logit, x) = logit_logabsdetjac.(x, b.a, b.b)
+logit_logabsdetjac(x, a, b) = -log((x - a) * (b - x) / (b - a))

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -7,17 +7,20 @@ function replace_diag(f, X)
     g(i, j) = ifelse(i == j, f(X[i, i]), X[i, j])
     return g.(1:size(X, 1), (1:size(X, 2))')
 end
-function (b::PDBijector)(X::AbstractMatrix{<:Real})
-    Y = cholesky(X; check = true).L
+(b::PDBijector)(X::AbstractMatrix{<:Real}) = pd_link(X)
+function pd_link(X)
+    Y = lower(parent(cholesky(X; check = true).L))
     return replace_diag(log, Y)
 end
 (b::PDBijector)(X::AbstractArray{<:AbstractMatrix{<:Real}}) = map(b, X)
+lower(A::AbstractMatrix) = convert(typeof(A), LowerTriangular(A))
 
 function (ib::Inverse{<:PDBijector})(Y::AbstractMatrix{<:Real})
     X = replace_diag(exp, Y)
-    return LowerTriangular(X) * LowerTriangular(X)'
+    return getpd(X)
 end
 (ib::Inverse{<:PDBijector})(X::AbstractArray{<:AbstractMatrix{<:Real}}) = map(ib, X)
+getpd(X) = LowerTriangular(X) * LowerTriangular(X)'
 
 function logabsdetjac(b::PDBijector, X::AbstractMatrix{<:Real})
     T = eltype(X)

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -18,3 +18,20 @@ function (ib::Inverse{<:PDBijector})(Y::AbstractMatrix{<:Real})
     return LowerTriangular(X) * LowerTriangular(X)'
 end
 (ib::Inverse{<:PDBijector})(X::AbstractArray{<:AbstractMatrix{<:Real}}) = map(ib, X)
+
+function logabsdetjac(b::PDBijector, X::AbstractMatrix{<:Real})
+    T = eltype(X)
+    Xcf = cholesky(X, check = false)
+    if !issuccess(Xcf)
+        Xcf = cholesky(X + max(eps(T), eps(T) * norm(X)) * I)
+    end
+
+    return logabsdetjac(b, Xcf)
+end
+
+function Bijectors.logabsdetjac(b::Bijectors.PDBijector, Xcf::Cholesky)
+    U = Xcf.U
+    T = eltype(U)
+    d = size(U, 1)
+    return - sum((d .- (1:d) .+ 2) .* log.(diag(U))) + d * log(T(2))
+end

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -36,6 +36,6 @@ function Bijectors.logabsdetjac(b::Bijectors.PDBijector, Xcf::Cholesky)
     return - sum((d .- (1:d) .+ 2) .* log.(diag(U))) + d * log(T(2))
 end
 
-logabsdetjac(b::PDBijector, X::AbstractArray{<:AbstractMatrix{<:Real}}) = map(X) do x
+logabsdetjac(b::PDBijector, X::AbstractArray{<:AbstractMatrix{<:Real}}) = mapvcat(X) do x
     logabsdetjac(b, x)
 end

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -35,3 +35,7 @@ function Bijectors.logabsdetjac(b::Bijectors.PDBijector, Xcf::Cholesky)
     d = size(U, 1)
     return - sum((d .- (1:d) .+ 2) .* log.(diag(U))) + d * log(T(2))
 end
+
+logabsdetjac(b::PDBijector, X::AbstractArray{<:AbstractMatrix{<:Real}}) = map(X) do x
+    logabsdetjac(b, x)
+end

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -29,7 +29,7 @@ function logabsdetjac(b::PDBijector, X::AbstractMatrix{<:Real})
     return logabsdetjac(b, Xcf)
 end
 
-function Bijectors.logabsdetjac(b::Bijectors.PDBijector, Xcf::Cholesky)
+function logabsdetjac(b::PDBijector, Xcf::Cholesky)
     U = Xcf.U
     T = eltype(U)
     d = size(U, 1)

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -11,7 +11,10 @@ function (b::PDBijector)(X::AbstractMatrix{<:Real})
     Y = cholesky(X; check = true).L
     return replace_diag(log, Y)
 end
+(b::PDBijector)(X::AbstractArray{<:AbstractMatrix{<:Real}}) = map(b, X)
+
 function (ib::Inverse{<:PDBijector})(Y::AbstractMatrix{<:Real})
     X = replace_diag(exp, Y)
     return LowerTriangular(X) * LowerTriangular(X)'
 end
+(ib::Inverse{<:PDBijector})(X::AbstractArray{<:AbstractMatrix{<:Real}}) = map(ib, X)

--- a/src/bijectors/simplex.jl
+++ b/src/bijectors/simplex.jl
@@ -4,13 +4,6 @@
 struct SimplexBijector{T} <: Bijector{1} where {T} end
 SimplexBijector() = SimplexBijector{true}()
 
-function _clamp(x::T, b::Union{SimplexBijector, Inverse{<:SimplexBijector}}) where {T}
-    bounds = (zero(T), one(T))
-    clamped_x = clamp(x, bounds...)
-    DEBUG && _debug("x = $x, bounds = $bounds, clamped_x = $clamped_x")
-    return clamped_x
-end
-
 (b::SimplexBijector)(x::AbstractVector) = _simplex_bijector(x, b)
 (b::SimplexBijector)(y::AbstractVector, x::AbstractVector) = _simplex_bijector!(y, x, b)
 function _simplex_bijector(x::AbstractVector, b::SimplexBijector)
@@ -97,18 +90,18 @@ function _simplex_inv_bijector!(x, y::AbstractVector, b::SimplexBijector{proj}) 
     T = eltype(y)
     ϵ = _eps(T)
     @inbounds z = StatsFuns.logistic(y[1] - log(T(K - 1)))
-    @inbounds x[1] = _clamp((z - ϵ) / (one(T) - 2ϵ), b)
+    @inbounds x[1] = _clamp((z - ϵ) / (one(T) - 2ϵ), 0, 1)
     sum_tmp = zero(T)
     @inbounds @simd for k = 2:(K - 1)
         z = StatsFuns.logistic(y[k] - log(T(K - k)))
         sum_tmp += x[k-1]
-        x[k] = _clamp(((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ, b)
+        x[k] = _clamp(((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ, 0, 1)
     end
     @inbounds sum_tmp += x[K - 1]
     @inbounds if proj
-        x[K] = _clamp(one(T) - sum_tmp, b)
+        x[K] = _clamp(one(T) - sum_tmp, 0, 1)
     else
-        x[K] = _clamp(one(T) - sum_tmp - y[K], b)
+        x[K] = _clamp(one(T) - sum_tmp - y[K], 0, 1)
     end
     
     return x
@@ -134,17 +127,17 @@ function _simplex_inv_bijector!(X, Y::AbstractMatrix, b::SimplexBijector{proj}) 
     ϵ = _eps(T)
     @inbounds @simd for n in 1:size(X, 2)
         sum_tmp, z = zero(T), StatsFuns.logistic(Y[1, n] - log(T(K - 1)))
-        X[1, n] = _clamp((z - ϵ) / (one(T) - 2ϵ), b)
+        X[1, n] = _clamp((z - ϵ) / (one(T) - 2ϵ), 0, 1)
         for k in 2:(K - 1)
             z = StatsFuns.logistic(Y[k, n] - log(T(K - k)))
             sum_tmp += X[k - 1, n]
-            X[k, n] = _clamp(((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ, b)
+            X[k, n] = _clamp(((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ, 0, 1)
         end
         sum_tmp += X[K - 1, n]
         if proj
-            X[K, n] = _clamp(one(T) - sum_tmp, b)
+            X[K, n] = _clamp(one(T) - sum_tmp, 0, 1)
         else
-            X[K, n] = _clamp(one(T) - sum_tmp - Y[K, n], b)
+            X[K, n] = _clamp(one(T) - sum_tmp - Y[K, n], 0, 1)
         end
     end
 
@@ -159,11 +152,11 @@ function logabsdetjac(b::SimplexBijector, x::AbstractVector{T}) where {T}
 
     sum_tmp = zero(eltype(x))
     @inbounds z = x[1]
-    lp += log(z + ϵ) + log((one(T) + ϵ) - z)
+    lp += log(max(z, ϵ)) + log(max(one(T) - z, ϵ))
     @inbounds @simd for k in 2:(K - 1)
         sum_tmp += x[k-1]
-        z = x[k] / ((one(T) + ϵ) - sum_tmp)
-        lp += log(z + ϵ) + log((one(T) + ϵ) - z) + log((one(T) + ϵ) - sum_tmp)
+        z = x[k] / max(one(T) - sum_tmp, ϵ)
+        lp += log(max(z, ϵ)) + log(max(one(T) - z, ϵ)) + log(max(one(T) - sum_tmp, ϵ))
     end
 
     return -lp
@@ -177,108 +170,86 @@ function simplex_logabsdetjac_gradient(x::AbstractVector)
     sum_tmp = zero(eltype(x))
     @inbounds z = x[1]
     #lp += log(z + ϵ) + log((one(T) + ϵ) - z)
-    g[1] = -1/(z + ϵ) + 1/((one(T) + ϵ) - z)
+    c1 = z >= ϵ
+    zc = one(T) - z
+    c2 = zc >= ϵ
+    g[1] = ifelse(c1 & c2, -1/z + 1/zc, ifelse(c1, -1/z, 1/zc))
     @inbounds @simd for k in 2:(K - 1)
         sum_tmp += x[k-1]
-        temp = ((one(T) + ϵ) - sum_tmp)
-        z = x[k] / temp
+        temp = 1 / (1 - sum_tmp)
+        c0 = temp >= ϵ
+        z = ifelse(c0, x[k] * temp, x[k] / ϵ)
         #lp += log(z + ϵ) + log((one(T) + ϵ) - z) + log(temp)
-        dzdx = 1 / temp
-        dldz = (1/(z + ϵ) - 1/((one(T) + ϵ) - z))
+        dzdx = ifelse(c0, temp, one(T))
+        c1 = z >= ϵ
+        zc = one(T) - z
+        c2 = zc >= ϵ
+        dldz = ifelse(c1 & c2, 1/z - 1/zc, ifelse(c1, 1/z, -1/zc))
         dldx = dldz * dzdx
-	    g[k] -= (1/(z + ϵ) - 1/((one(T) + ϵ) - z)) * 1 / ((one(T) + ϵ) - sum_tmp)
+	    g[k] -= dldx
         for i in 1:k-1
-	        dzdxp = x[k] * dzdx^2
-	        dldxp = dldz * dzdxp - 1 / temp
+	        dzdxp = ifelse(c0, x[k] * dzdx^2, zero(T))
+	        dldxp = dldz * dzdxp - ifelse(c0, temp, zero(T))
 	        g[i] -= dldxp
 	    end
     end
     return g
 end
-function logabsdetjac(b::SimplexBijector, x::AbstractMatrix{<:Real})
-    mapvcat(eachcol(x)) do c
-        logabsdetjac(b, c)
-    end
-end
-
-#=
-function simplex_link_val_adjoint(
-    x::AbstractVector{T},
-    Δ::AbstractVector,
-    proj::Bool = true,
-) where {T <: Real}
-    K = length(x)
-    @assert K > 1 "x needs to be of length greater than 1"
-    y = similar(x)
+function logabsdetjac(b::SimplexBijector, x::AbstractMatrix{T}) where {T}
     ϵ = _eps(T)
-    sum_tmp = zero(T)
-    nΔ = zeros(T, length(Δ))
-    @inbounds z = x[1] * (one(T) - 2ϵ) + ϵ # z ∈ [ϵ, 1-ϵ]
-    @inbounds y[1] = StatsFuns.logit(z) + log(T(K - 1))
-    @inbounds nΔ[1] = Δ[1] * (1/z + 1/(1-z)) * (one(T) - 2ϵ)
-    @inbounds @simd for k in 2:(K - 1)
-        sum_tmp += x[k - 1]
-        # z ∈ [ϵ, 1-ϵ]
-        # x[k] = 0 && sum_tmp = 1 -> z ≈ 1
-        z = (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
-        y[k] = StatsFuns.logit(z) + log(T(K - k))
-        nΔ[k] += Δ[k] * (1/z + 1/(1-z)) * (one(T) - 2ϵ) / ((one(T) + ϵ) - sum_tmp)
-        for i in 1:k-1
-            nΔ[i] += Δ[k] * (1/z + 1/(1-z)) * (x[k] + ϵ) * (one(T) - 2ϵ) / ((one(T) + ϵ) - sum_tmp)^2
-        end
-    end
-    @inbounds sum_tmp += x[K - 1]
-    @inbounds if proj
-        y[K] = zero(T)
-    else
-        y[K] = one(T) - sum_tmp - x[K]
-        @simd for i in 1:K
-            nΔ[i] += -Δ[K]
-        end
-    end
+    nlp = similar(x, T, size(x, 2))
+    nlp .= zero(T)
 
-    return y, nΔ
+    K = size(x, 1)
+    for col in 1:size(x, 2)
+        sum_tmp = zero(eltype(x))
+        z = x[1,col]
+        nlp[col] -= log(max(z, ϵ)) + log(max(one(T) - z, ϵ))
+        for k in 2:(K - 1)
+            sum_tmp += x[k-1,col]
+            z = x[k,col] / max(one(T) - sum_tmp, ϵ)
+            nlp[col] -= log(max(z, ϵ)) + log(max(one(T) - z, ϵ)) + log(max(one(T) - sum_tmp, ϵ))
+        end
+    end
+    return nlp
 end
-
-function simplex_link_val_jacobian(
-    x::AbstractVector{T},
-    proj::Bool = true,
-) where {T <: Real}
-    K = length(x)
-    @assert K > 1 "x needs to be of length greater than 1"
-    y = similar(x)
-    dydxt = similar(x, length(x), length(x))
-    @inbounds dydxt .= 0
+function simplex_logabsdetjac_gradient(x::AbstractMatrix)
+    T = eltype(x)
     ϵ = _eps(T)
-    sum_tmp = zero(T)
-
-    @inbounds z = x[1] * (one(T) - 2ϵ) + ϵ # z ∈ [ϵ, 1-ϵ]
-    @inbounds y[1] = StatsFuns.logit(z) + log(T(K - 1))
-    @inbounds dydxt[1,1] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)
-    @inbounds @simd for k in 2:(K - 1)
-        sum_tmp += x[k - 1]
-        # z ∈ [ϵ, 1-ϵ]
-        # x[k] = 0 && sum_tmp = 1 -> z ≈ 1
-        z = (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
-        y[k] = StatsFuns.logit(z) + log(T(K - k))
-        dydxt[k,k] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
-        for i in 1:k-1
-            dydxt[i,k] = (1/z + 1/(1-z)) * (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)^2
+    K = size(x, 1)
+    g = similar(x)
+    g .= 0
+    @inbounds @simd for col in 1:size(x, 2)
+        sum_tmp = zero(eltype(x))
+        z = x[1,col]
+        #lp += log(z + ϵ) + log((one(T) + ϵ) - z)
+        c1 = z >= ϵ
+        zc = one(T) - z
+        c2 = zc >= ϵ
+        g[1,col] = ifelse(c1 & c2, -1/z + 1/zc, ifelse(c1, -1/z, 1/zc))
+        for k in 2:(K - 1)
+            sum_tmp += x[k-1,col]
+            temp = 1 / (1 - sum_tmp)
+            c0 = temp >= ϵ
+            z = ifelse(c0, x[k,col] * temp, x[k,col] / ϵ)
+            #lp += log(z + ϵ) + log((one(T) + ϵ) - z) + log(temp)
+            dzdx = ifelse(c0, temp, one(T))
+            c1 = z >= ϵ
+            zc = one(T) - z
+            c2 = zc >= ϵ
+            dldz = ifelse(c1 & c2, 1/z - 1/zc, ifelse(c1, 1/z, -1/zc))
+            dldx = dldz * dzdx
+            g[k,col] -= dldx
+            for i in 1:k-1
+                dzdxp = ifelse(c0, x[k,col] * dzdx^2, zero(T))
+                dldxp = dldz * dzdxp - ifelse(c0, temp, zero(T))
+                g[i,col] -= dldxp
+            end
         end
     end
-    @inbounds sum_tmp += x[K - 1]
-    @inbounds if proj
-        y[K] = zero(T)
-    else
-        y[K] = one(T) - sum_tmp - x[K]
-        @simd for i in 1:K
-            dydxt[i,K] = -1
-        end
-    end
-
-    return y, UpperTriangular(dydxt)'
+    return g
 end
-=#
+
 function simplex_link_jacobian(
     x::AbstractVector{T},
     proj::Bool = true,
@@ -308,130 +279,78 @@ function simplex_link_jacobian(
             dydxt[i,K] = -1
         end
     end
-
     return UpperTriangular(dydxt)'
+end
+function jacobian(b::SimplexBijector{proj}, x::AbstractVector{T}) where {proj, T}
+    return simplex_link_jacobian(x, proj)
 end
 
 #=
-function simplex_invlink_val_adjoint(
-    y::AbstractVector{T},
-    Δ::AbstractVector,
+# This approach is faster for small random variables
+# For larger ones, building the Jacobian and multiplying is faster because of BLAS.
+
+function add_simplex_link_adjoint!(
+    inΔ::AbstractVector,
+    x::AbstractVector{T},
+    outΔ::AbstractVector,
     proj::Bool = true,
 ) where {T <: Real}
-    K = length(y)
+    K = length(x)
     @assert K > 1 "x needs to be of length greater than 1"
-    x = similar(y)
-    nΔ = similar(Δ)
-    @inbounds nΔ .= 0
-    dxdy = similar(y, length(y), length(y))
-    @inbounds dxdy .= 0
-
     ϵ = _eps(T)
-    @inbounds z = StatsFuns.logistic(y[1] - log(T(K - 1)))
-    unclamped_x = (z - ϵ) / (one(T) - 2ϵ)
-    clamped_x = _clamp(unclamped_x, SimplexBijector())
-    @inbounds x[1] = clamped_x
-    @inbounds if unclamped_x == clamped_x
-        dxdy[1,1] = z * (1 - z) / (one(T) - 2ϵ)
-        nΔ[1] = Δ[1] * dxdy[1,1]
-    end
     sum_tmp = zero(T)
-    @inbounds for k = 2:(K - 1)
-        z = StatsFuns.logistic(y[k] - log(T(K - k)))
-        sum_tmp += clamped_x
-        unclamped_x = ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
-        x[k] = clamped_x
-        if unclamped_x == clamped_x
-            dxdy[k,k] = z * (1 - z) * ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ)
-            nΔ[k] = Δ[k] * dxdy[k,k]
-            for i in 1:k-1
-                for j in i:k-1
-                    temp = -dxdy[j,i] * z / (one(T) - 2ϵ)
-                    dxdy[k,i] += temp
-                    nΔ[i] += Δ[k] * temp
-                end
-            end
+    @inbounds z = x[1] * (one(T) - 2ϵ) + ϵ # z ∈ [ϵ, 1-ϵ]
+    @inbounds inΔ[1] += outΔ[1] * (1/z + 1/(1-z)) * (one(T) - 2ϵ)
+    @inbounds @simd for k in 2:(K - 1)
+        sum_tmp += x[k - 1]
+        # z ∈ [ϵ, 1-ϵ]
+        # x[k] = 0 && sum_tmp = 1 -> z ≈ 1
+        z = (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
+        inΔ[k] += outΔ[k] * (1/z + 1/(1-z)) * (one(T) - 2ϵ) / ((one(T) + ϵ) - sum_tmp)
+        for i in 1:k-1
+            inΔ[i] += outΔ[k] * (1/z + 1/(1-z)) * (x[k] + ϵ) * (one(T) - 2ϵ) / ((one(T) + ϵ) - sum_tmp)^2
         end
     end
-    @inbounds sum_tmp += clamped_x
-    @inbounds if proj
-    	unclamped_x = one(T) - sum_tmp
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
-    else
-    	unclamped_x = one(T) - sum_tmp - y[K]
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
-        if unclamped_x == clamped_x
-            nΔ[K] = -Δ[K]
+    if !proj
+        for i in 1:K
+            inΔ[i] += -outΔ[K]
         end
     end
-    x[K] = clamped_x
-    @inbounds if unclamped_x == clamped_x
-        for i in 1:K-1
-            @simd for j in i:K-1
-                nΔ[i] += -Δ[K] * dxdy[j,i]
-            end
-        end
-    end
-    return x, nΔ
+    return inΔ
 end
-
-function simplex_invlink_val_jacobian(
-    y::AbstractVector{T},
+function add_simplex_link_adjoint!(
+    inΔ::AbstractMatrix,
+    x::AbstractMatrix{T},
+    outΔ::AbstractMatrix,
     proj::Bool = true,
 ) where {T <: Real}
-    K = length(y)
+    K = size(x, 1)
     @assert K > 1 "x needs to be of length greater than 1"
-    x = similar(y)
-    dxdy = similar(y, length(y), length(y))
-    @inbounds dxdy .= 0
-
     ϵ = _eps(T)
-    @inbounds z = StatsFuns.logistic(y[1] - log(T(K - 1)))
-    unclamped_x = (z - ϵ) / (one(T) - 2ϵ)
-    clamped_x = _clamp(unclamped_x, SimplexBijector())
-    @inbounds x[1] = clamped_x
-    @inbounds if unclamped_x == clamped_x
-        dxdy[1,1] = z * (1 - z) / (one(T) - 2ϵ)
-    end
-    sum_tmp = zero(T)
-    @inbounds for k = 2:(K - 1)
-        z = StatsFuns.logistic(y[k] - log(T(K - k)))
-        sum_tmp += clamped_x
-        unclamped_x = ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
-        x[k] = clamped_x
-        if unclamped_x == clamped_x
-            dxdy[k,k] = z * (1 - z) * ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ)
+    @inbounds for col in 1:size(x, 2)
+        sum_tmp = zero(T)
+        z = x[1,col] * (one(T) - 2ϵ) + ϵ # z ∈ [ϵ, 1-ϵ]
+        inΔ[1,col] += outΔ[1,col] * (1/z + 1/(1-z)) * (one(T) - 2ϵ)
+        @simd for k in 2:(K - 1)
+            sum_tmp += x[k-1, col]
+            # z ∈ [ϵ, 1-ϵ]
+            # x[k] = 0 && sum_tmp = 1 -> z ≈ 1
+            z = (x[k,col] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
+            inΔ[k,col] += outΔ[k,col] * (1/z + 1/(1-z)) * (one(T) - 2ϵ) / ((one(T) + ϵ) - sum_tmp)
             for i in 1:k-1
-                for j in i:k-1
-                    dxdy[k,i] += -dxdy[j,i] * z / (one(T) - 2ϵ)
-                end
+                inΔ[i,col] += outΔ[k,col] * (1/z + 1/(1-z)) * (x[k,col] + ϵ) * (one(T) - 2ϵ) / ((one(T) + ϵ) - sum_tmp)^2
+            end
+        end
+        if !proj
+            @simd for i in 1:K
+                inΔ[i,col] += -outΔ[K,col]
             end
         end
     end
-    @inbounds sum_tmp += clamped_x
-    @inbounds if proj
-    	unclamped_x = one(T) - sum_tmp
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
-    else
-    	unclamped_x = one(T) - sum_tmp - y[K]
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
-        if unclamped_x == clamped_x
-            dxdy[K,K] = -1
-        end
-    end
-    x[K] = clamped_x
-    @inbounds if unclamped_x == clamped_x
-        for i in 1:K-1
-            @simd for j in i:K-1
-                dxdy[K,i] += -dxdy[j,i]
-            end
-        end
-    end
-    return x, LowerTriangular(dxdy)
+    return inΔ
 end
 =#
+
 function simplex_invlink_jacobian(
     y::AbstractVector{T},
     proj::Bool = true,
@@ -444,7 +363,7 @@ function simplex_invlink_jacobian(
     ϵ = _eps(T)
     @inbounds z = StatsFuns.logistic(y[1] - log(T(K - 1)))
     unclamped_x = (z - ϵ) / (one(T) - 2ϵ)
-    clamped_x = _clamp(unclamped_x, SimplexBijector())
+    clamped_x = _clamp(unclamped_x, 0, 1)
     @inbounds if unclamped_x == clamped_x
         dxdy[1,1] = z * (1 - z) / (one(T) - 2ϵ)
     end
@@ -453,7 +372,7 @@ function simplex_invlink_jacobian(
         z = StatsFuns.logistic(y[k] - log(T(K - k)))
         sum_tmp += clamped_x
         unclamped_x = ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
+        clamped_x = _clamp(unclamped_x, 0, 1)
         if unclamped_x == clamped_x
             dxdy[k,k] = z * (1 - z) * ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ)
             for i in 1:k-1
@@ -466,10 +385,10 @@ function simplex_invlink_jacobian(
     @inbounds sum_tmp += clamped_x
     @inbounds if proj
     	unclamped_x = one(T) - sum_tmp
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
+        clamped_x = _clamp(unclamped_x, 0, 1)
     else
     	unclamped_x = one(T) - sum_tmp - y[K]
-        clamped_x = _clamp(unclamped_x, SimplexBijector())
+        clamped_x = _clamp(unclamped_x, 0, 1)
         if unclamped_x == clamped_x
             dxdy[K,K] = -1
         end
@@ -483,62 +402,48 @@ function simplex_invlink_jacobian(
     end
     return LowerTriangular(dxdy)
 end
-
 # jacobian
-function jacobian(b::SimplexBijector{proj}, x::AbstractVector{T}) where {proj, T}
-    K = length(x)
-    dydxt = similar(x, length(x), length(x))
-    @inbounds dydxt .= 0
-    ϵ = _eps(T)
-    sum_tmp = zero(T)
-
-    @inbounds z = x[1] * (one(T) - 2ϵ) + ϵ # z ∈ [ϵ, 1-ϵ]
-    @inbounds dydxt[1,1] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)
-    @inbounds @simd for k in 2:(K - 1)
-        sum_tmp += x[k - 1]
-        # z ∈ [ϵ, 1-ϵ]
-        # x[k] = 0 && sum_tmp = 1 -> z ≈ 1
-        z = (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
-        dydxt[k,k] = (1/z + 1/(1-z)) * (one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)
-        for i in 1:k-1
-            dydxt[i,k] = (1/z + 1/(1-z)) * (x[k] + ϵ)*(one(T) - 2ϵ)/((one(T) + ϵ) - sum_tmp)^2
-        end
-    end
-    @inbounds sum_tmp += x[K - 1]
-    @inbounds if !proj
-        @simd for i in 1:K
-            dydxt[i,K] = -1
-        end
-    end
-
-    return UpperTriangular(dydxt)'
+function jacobian(ib::Inverse{<:SimplexBijector{proj}}, y::AbstractVector{T}) where {proj, T}
+    return simplex_invlink_jacobian(y, proj)
 end
 
-function jacobian(ib::Inverse{<:SimplexBijector{proj}}, y::AbstractVector{T}) where {proj, T}
-    b = ib.orig
-    
-    K = length(y)
-    dxdy = similar(y, length(y), length(y))
-    @inbounds dxdy .= 0
+#=
+# This approach is faster for small random variables
+# For larger ones, building the Jacobian and multiplying is faster because of BLAS.
 
+function add_simplex_invlink_adjoint!(
+    inΔ::AbstractVector,
+    y::AbstractVector{T},
+    outΔ::AbstractVector,
+    proj::Bool = true,
+) where {T <: Real}
+    K = length(y)
+    @assert K > 1 "x needs to be of length greater than 1"
+    dxdy = similar(y, length(y), length(y))
+
+    @inbounds dxdy .= 0
     ϵ = _eps(T)
     @inbounds z = StatsFuns.logistic(y[1] - log(T(K - 1)))
     unclamped_x = (z - ϵ) / (one(T) - 2ϵ)
-    clamped_x = _clamp(unclamped_x, b)
+    clamped_x = _clamp(unclamped_x, 0, 1)
     @inbounds if unclamped_x == clamped_x
         dxdy[1,1] = z * (1 - z) / (one(T) - 2ϵ)
+        inΔ[1] += outΔ[1] * dxdy[1,1]
     end
     sum_tmp = zero(T)
     @inbounds for k = 2:(K - 1)
         z = StatsFuns.logistic(y[k] - log(T(K - k)))
         sum_tmp += clamped_x
         unclamped_x = ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ
-        clamped_x = _clamp(unclamped_x, b)
+        clamped_x = _clamp(unclamped_x, 0, 1)
         if unclamped_x == clamped_x
             dxdy[k,k] = z * (1 - z) * ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ)
+            inΔ[k] += outΔ[k] * dxdy[k,k]
             for i in 1:k-1
                 for j in i:k-1
-                    dxdy[k,i] += -dxdy[j,i] * z / (one(T) - 2ϵ)
+                    temp = -dxdy[j,i] * z / (one(T) - 2ϵ)
+                    dxdy[k,i] += temp
+                    inΔ[i] += outΔ[k] * temp
                 end
             end
         end
@@ -546,20 +451,80 @@ function jacobian(ib::Inverse{<:SimplexBijector{proj}}, y::AbstractVector{T}) wh
     @inbounds sum_tmp += clamped_x
     @inbounds if proj
     	unclamped_x = one(T) - sum_tmp
-        clamped_x = _clamp(unclamped_x, b)
+        clamped_x = _clamp(unclamped_x, 0, 1)
     else
     	unclamped_x = one(T) - sum_tmp - y[K]
-        clamped_x = _clamp(unclamped_x, b)
+        clamped_x = _clamp(unclamped_x, 0, 1)
         if unclamped_x == clamped_x
-            dxdy[K,K] = -1
+            inΔ[K] += -outΔ[K]
         end
     end
     @inbounds if unclamped_x == clamped_x
         for i in 1:K-1
             @simd for j in i:K-1
-                dxdy[K,i] += -dxdy[j,i]
+                inΔ[i] += -outΔ[K] * dxdy[j,i]
             end
         end
     end
-    return LowerTriangular(dxdy)
+    return inΔ
 end
+function add_simplex_invlink_adjoint!(
+    inΔ::AbstractMatrix,
+    y::AbstractMatrix{T},
+    outΔ::AbstractMatrix,
+    proj::Bool = true,
+) where {T <: Real}
+    K = size(y,1)
+    @assert K > 1 "x needs to be of length greater than 1"
+    dxdy = similar(y, size(y,1), size(y,1))
+
+    @inbounds for col in 1:size(y,2)
+        dxdy .= 0
+        ϵ = _eps(T)
+        z = StatsFuns.logistic(y[1,col] - log(T(K - 1)))
+        unclamped_x = (z - ϵ) / (one(T) - 2ϵ)
+        clamped_x = _clamp(unclamped_x, 0, 1)
+        if unclamped_x == clamped_x
+            dxdy[1,1] = z * (1 - z) / (one(T) - 2ϵ)
+            inΔ[1,col] += outΔ[1,col] * dxdy[1,1]
+        end
+        sum_tmp = zero(T)
+        for k = 2:(K - 1)
+            z = StatsFuns.logistic(y[k,col] - log(T(K - k)))
+            sum_tmp += clamped_x
+            unclamped_x = ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ) * z - ϵ
+            clamped_x = _clamp(unclamped_x, 0, 1)
+            if unclamped_x == clamped_x
+                dxdy[k,k] = z * (1 - z) * ((one(T) + ϵ) - sum_tmp) / (one(T) - 2ϵ)
+                inΔ[k,col] += outΔ[k,col] * dxdy[k,k]
+                for i in 1:k-1
+                    @simd for j in i:k-1
+                        temp = -dxdy[j,i] * z / (one(T) - 2ϵ)
+                        dxdy[k,i] += temp
+                        inΔ[i,col] += outΔ[k,col] * temp
+                    end
+                end
+            end
+        end
+        @inbounds sum_tmp += clamped_x
+        @inbounds if proj
+            unclamped_x = one(T) - sum_tmp
+            clamped_x = _clamp(unclamped_x, 0, 1)
+        else
+            unclamped_x = one(T) - sum_tmp - y[K]
+            clamped_x = _clamp(unclamped_x, 0, 1)
+            if unclamped_x == clamped_x
+                inΔ[K,col] += -outΔ[K,col]
+            end
+        end
+        @inbounds if unclamped_x == clamped_x
+            for i in 1:K-1
+                @simd for j in i:K-1
+                    inΔ[i,col] += -outΔ[K,col] * dxdy[j,i]
+                end
+            end
+        end
+    end
+    return inΔ
+end
+=#

--- a/src/bijectors/stacked.jl
+++ b/src/bijectors/stacked.jl
@@ -78,7 +78,7 @@ function (sb::Stacked{<:Tuple})(x::AbstractVector{<:Real})
 end
 # The Stacked{<:AbstractArray} version is not TrackedArray friendly
 function (sb::Stacked{<:AbstractArray, N})(x::AbstractVector{<:Real}) where {N}
-    y = mapvcat2(1:N) do i
+    y = mapvcat(1:N) do i
         sb.bs[i](x[sb.ranges[i]])
     end
     @assert size(y) == size(x) "x is size $(size(x)) but y is $(size(y))"
@@ -97,7 +97,7 @@ function logabsdetjac(
 end
 
 function logabsdetjac(b::Stacked, x::AbstractMatrix{<:Real})
-    return mapvcat(eachcol(x)) do c
+    return map(eachcol(x)) do c
         logabsdetjac(b, c)
     end
 end
@@ -136,7 +136,7 @@ end
 function forward(sb::Stacked{<:AbstractArray, N}, x::AbstractVector) where {N}
     yinit, linit = forward(sb.bs[1], x[sb.ranges[1]])
     logjac = sum(linit)
-    ys = mapvcat2(drop(sb.bs, 1), drop(sb.ranges, 1)) do b, r
+    ys = mapvcat(drop(sb.bs, 1), drop(sb.ranges, 1)) do b, r
         y, l = forward(b, x[r])
         logjac += sum(l)
         y

--- a/src/bijectors/truncated.jl
+++ b/src/bijectors/truncated.jl
@@ -1,9 +1,9 @@
 #######################################################
 # Constrained to unconstrained distribution bijectors #
 #######################################################
-struct TruncatedBijector{T} <: Bijector{0}
-    lb::T
-    ub::T
+struct TruncatedBijector{T1, T2} <: Bijector{0}
+    lb::T1
+    ub::T2
 end
 
 function (b::TruncatedBijector)(x::Real)

--- a/src/bijectors/truncated.jl
+++ b/src/bijectors/truncated.jl
@@ -8,6 +8,13 @@ end
 
 function (b::TruncatedBijector)(x::Real)
     a, b = b.lb, b.ub
+    truncated_link(_clamp(x, a, b), a, b)
+end 
+function (b::TruncatedBijector)(x::AbstractArray{<:Real})
+    a, b = b.lb, b.ub
+    truncated_link.(_clamp.(x, a, b), a, b)
+end
+function truncated_link(x::Real, a, b)
     lowerbounded, upperbounded = isfinite(a), isfinite(b)
     if lowerbounded && upperbounded
         return StatsFuns.logit((x - a) / (b - a))
@@ -17,25 +24,18 @@ function (b::TruncatedBijector)(x::Real)
         return log(b - x)
     else
         return x
-    end 
-end
-
-function (b::TruncatedBijector)(x::AbstractVector{<:Real})
-    a, b = b.lb, b.ub
-    lowerbounded, upperbounded = isfinite(a), isfinite(b)
-    if lowerbounded && upperbounded
-        return @. StatsFuns.logit((x - a) / (b - a))
-    elseif lowerbounded
-        return @. log(x - a)
-    elseif upperbounded
-        return @. log(b - x)
-    else
-        return x
     end
 end
 
 function (ib::Inverse{<:TruncatedBijector})(y::Real)
     a, b = ib.orig.lb, ib.orig.ub
+    _clamp(truncated_invlink(y, a, b), a, b)
+end
+function (ib::Inverse{<:TruncatedBijector})(y::AbstractArray{<:Real})
+    a, b = ib.orig.lb, ib.orig.ub
+    _clamp.(truncated_invlink.(y, a, b), a, b)
+end
+function truncated_invlink(y, a, b)
     lowerbounded, upperbounded = isfinite(a), isfinite(b)
     if lowerbounded && upperbounded
         return (b - a) * StatsFuns.logistic(y) + a
@@ -48,22 +48,15 @@ function (ib::Inverse{<:TruncatedBijector})(y::Real)
     end
 end
 
-function (ib::Inverse{<:TruncatedBijector})(y::AbstractVector{<:Real})
-    a, b = ib.orig.lb, ib.orig.ub
-    lowerbounded, upperbounded = isfinite(a), isfinite(b)
-    if lowerbounded && upperbounded
-        return @. (b - a) * StatsFuns.logistic(y) + a
-    elseif lowerbounded
-        return @. exp(y) + a
-    elseif upperbounded
-        return @. b - exp(y)
-    else
-        return y
-    end
-end
-
 function logabsdetjac(b::TruncatedBijector, x::Real)
     a, b = b.lb, b.ub
+    truncated_logabsdetjac(_clamp(x, a, b), a, b)
+end
+function logabsdetjac(b::TruncatedBijector, x::AbstractArray{<:Real})
+    a, b = b.lb, b.ub
+    truncated_logabsdetjac.(_clamp.(x, a, b), a, b)
+end
+function truncated_logabsdetjac(x, a, b)
     lowerbounded, upperbounded = isfinite(a), isfinite(b)
     if lowerbounded && upperbounded
         return - log((x - a) * (b - x) / (b - a))
@@ -75,18 +68,3 @@ function logabsdetjac(b::TruncatedBijector, x::Real)
         return zero(x)
     end
 end
-
-function logabsdetjac(b::TruncatedBijector, x::AbstractVector{<:Real})
-    a, b = b.lb, b.ub
-    lowerbounded, upperbounded = isfinite(a), isfinite(b)
-    if lowerbounded && upperbounded
-        return @. - log((x - a) * (b - x) / (b - a))
-    elseif lowerbounded
-        return @. - log(x - a)
-    elseif upperbounded
-        return @. - log(b - x)
-    else
-        return zero(x)
-    end
-end
-

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -126,34 +126,51 @@ end
 # filldist and arraydist
 
 function logpdf_with_trans(
-    dist::FillVectorOfUnivariate,
+    dist::FillVectorOfUnivariate{Discrete},
+    x::AbstractVecOrMat{<:Real},
+    istrans::Bool,
+)
+    return logpdf(dist, x)
+end
+function logpdf_with_trans(
+    dist::FillVectorOfUnivariate{Continuous},
     x::AbstractVector{<:Real},
     istrans::Bool,
 )
     return sum(logpdf_with_trans(dist.v.value, x, istrans))
 end
 function logpdf_with_trans(
-    dist::FillVectorOfUnivariate,
+    dist::FillVectorOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
     return vec(sum(logpdf_with_trans(dist.v.value, x, istrans), dims = 1))
 end
 
-link(dist::FillVectorOfUnivariate{Discrete}, x::AbstractVector{<:Real}) = copy(x)
-link(dist::FillVectorOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
+link(dist::FillVectorOfUnivariate{Discrete}, x::AbstractVecOrMat{<:Real}) = copy(x)
 function link(
     dist::FillVectorOfUnivariate{Continuous},
     x::AbstractVector{<:Real},
 )
     return link(dist.v.value, x)
 end
+function link(
+    dist::FillVectorOfUnivariate{Continuous},
+    x::AbstractMatrix{<:Real},
+)
+    return link(dist.v.value, x)
+end
 
-invlink(dist::FillVectorOfUnivariate{Discrete}, x::AbstractVector{<:Real}) = copy(x)
-invlink(dist::FillVectorOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
+invlink(dist::FillVectorOfUnivariate{Discrete}, x::AbstractVecOrMat{<:Real}) = copy(x)
 function invlink(
     dist::FillVectorOfUnivariate{Continuous},
     x::AbstractVector{<:Real},
+)
+    return invlink(dist.v.value, x)
+end
+function invlink(
+    dist::FillVectorOfUnivariate{Continuous},
+    x::AbstractMatrix{<:Real},
 )
     return invlink(dist.v.value, x)
 end
@@ -166,13 +183,13 @@ function logpdf_with_trans(
     return sum(logpdf_with_trans(dist.dists.value, x, istrans))
 end
 function link(
-    dist::FillMatrixOfUnivariate{Continuous},
+    dist::FillMatrixOfUnivariate,
     x::AbstractMatrix{<:Real},
 )
     return link(dist.dists.value, x)
 end
 function invlink(
-    dist::FillMatrixOfUnivariate{Continuous},
+    dist::FillMatrixOfUnivariate,
     x::AbstractMatrix{<:Real},
 )
     return invlink(dist.dists.value, x)
@@ -186,13 +203,13 @@ function logpdf_with_trans(
     return sum(logpdf_with_trans(dist.dists.value, x, istrans))
 end
 function link(
-    dist::FillVectorOfMultivariate{Continuous},
+    dist::FillVectorOfMultivariate,
     x::AbstractMatrix{<:Real},
 )
     return link(dist.dists.value, x)
 end
 function invlink(
-    dist::FillVectorOfMultivariate{Continuous},
+    dist::FillVectorOfMultivariate,
     x::AbstractMatrix{<:Real},
 )
     return invlink(dist.dists.value, x)
@@ -219,7 +236,7 @@ end
 
 link(dist::VectorOfMultivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
-    dist::VectorOfMultivariate,
+    dist::VectorOfMultivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return eachcolmaphcat(x, dist.dists) do c, dist
@@ -228,7 +245,7 @@ function link(
 end
 invlink(dist::VectorOfMultivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function invlink(
-    dist::VectorOfMultivariate,
+    dist::VectorOfMultivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return eachcolmaphcat(x, dist.dists) do c, dist
@@ -247,14 +264,14 @@ function logpdf_with_trans(
 end
 link(dist::MatrixOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
-    dist::MatrixOfUnivariate,
+    dist::MatrixOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return maporbroadcast(link, dist.dists, x)
 end
 invlink(dist::MatrixOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function invlink(
-    dist::MatrixOfUnivariate,
+    dist::MatrixOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return maporbroadcast(invlink, dist.dists, x)
@@ -270,24 +287,12 @@ function logpdf_with_trans(
     end
 end
 function link(
-    dist::Union{MatrixOfUnivariate{Discrete}, VectorOfMultivariate{Discrete}},
-    x::AbstractArray{<:AbstractMatrix{<:Real}},
-)
-    return map(copy, x)
-end
-function link(
     dist::Union{MatrixOfUnivariate, VectorOfMultivariate},
     x::AbstractArray{<:AbstractMatrix{<:Real}},
 )
     map(x) do x
         link(dist, x)
     end
-end
-function invlink(
-    dist::Union{MatrixOfUnivariate{Discrete}, VectorOfMultivariate{Discrete}},
-    x::AbstractArray{<:AbstractMatrix{<:Real}},
-)
-    return map(copy, x)
 end
 function invlink(
     dist::Union{MatrixOfUnivariate, VectorOfMultivariate},

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -271,19 +271,11 @@ function invlink(
     dist::VectorOfUnivariate,
     x::AbstractMatrix{<:Real},
 )
-<<<<<<< HEAD
-    return mapvcat(eachcol(x)) do x
-=======
     return eachcolmaphcat(x) do x
->>>>>>> master
         invlink(dist, x)
     end
 end
 
-<<<<<<< HEAD
-
-=======
->>>>>>> master
 function logpdf_with_trans(
     dist::MatrixOfUnivariate,
     x::AbstractMatrix{<:Real},

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -1,6 +1,15 @@
-using .DistributionsAD: TuringDirichlet, TuringWishart, TuringInverseWishart,
-                        FillVectorOfUnivariate, FillMatrixOfUnivariate, VectorOfUnivariate,
-                        MatrixOfUnivariate, FillVectorOfMultivariate, VectorOfMultivariate
+using .DistributionsAD:
+    TuringDirichlet, TuringWishart, TuringInverseWishart, TuringScalMvNormal,
+    TuringDenseMvNormal, TuringDiagMvNormal,
+    FillVectorOfUnivariate, FillMatrixOfUnivariate, VectorOfUnivariate,
+    MatrixOfUnivariate, FillVectorOfMultivariate, VectorOfMultivariate
+
+bijector(::TuringDirichlet) = SimplexBijector()
+bijector(::TuringWishart) = PDBijector()
+bijector(::TuringInverseWishart) = PDBijector()
+bijector(::TuringScalMvNormal) = Identity{1}()
+bijector(::TuringDiagMvNormal) = Identity{1}()
+bijector(::TuringDenseMvNormal) = Identity{1}()
 
 # TuringDirichlet
 

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -130,18 +130,20 @@ function logpdf_with_trans(
     x::AbstractVector{<:Real},
     istrans::Bool,
 )
-    return sum(map(x) do x
-        logpdf_with_trans(dist.v.value, x, istrans)
-    end)
+    return sum(logpdf_with_trans(dist.v.value, x, istrans))
 end
+
+link(dist::FillVectorOfUnivariate{Discrete}, x::AbstractVector{<:Real}) = copy(x)
 function link(
-    dist::FillVectorOfUnivariate,
+    dist::FillVectorOfUnivariate{Continuous},
     x::AbstractVector{<:Real},
 )
     return link(dist.v.value, x)
 end
+
+invlink(dist::FillVectorOfUnivariate{Discrete}, x::AbstractVector{<:Real}) = copy(x)
 function invlink(
-    dist::FillVectorOfUnivariate,
+    dist::FillVectorOfUnivariate{Continuous},
     x::AbstractVector{<:Real},
 )
     return invlink(dist.v.value, x)
@@ -152,18 +154,16 @@ function logpdf_with_trans(
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
-    return sum(map(x) do x
-        logpdf_with_trans(dist.dists.value, x, istrans)
-    end)
+    return sum(logpdf_with_trans(dist.dists.value, x, istrans))
 end
 function link(
-    dist::FillMatrixOfUnivariate,
+    dist::FillMatrixOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return link(dist.dists.value, x)
 end
 function invlink(
-    dist::FillMatrixOfUnivariate,
+    dist::FillMatrixOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return invlink(dist.dists.value, x)
@@ -177,13 +177,13 @@ function logpdf_with_trans(
     return sum(logpdf_with_trans(dist.dists.value, x, istrans))
 end
 function link(
-    dist::FillVectorOfMultivariate,
+    dist::FillVectorOfMultivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return link(dist.dists.value, x)
 end
 function invlink(
-    dist::FillVectorOfMultivariate,
+    dist::FillVectorOfMultivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return invlink(dist.dists.value, x)
@@ -207,6 +207,8 @@ function logpdf_with_trans(
         logpdf_with_trans(dist, x, istrans)
     end
 end
+
+link(dist::VectorOfMultivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
     dist::VectorOfMultivariate,
     x::AbstractMatrix{<:Real},
@@ -215,6 +217,7 @@ function link(
         link(dist, c)
     end
 end
+invlink(dist::VectorOfMultivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function invlink(
     dist::VectorOfMultivariate,
     x::AbstractMatrix{<:Real},
@@ -233,12 +236,14 @@ function logpdf_with_trans(
         logpdf_with_trans(dist, x, istrans)
     end)
 end
+link(dist::MatrixOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
     dist::MatrixOfUnivariate,
     x::AbstractMatrix{<:Real},
 )
     return maporbroadcast(link, dist.dists, x)
 end
+invlink(dist::MatrixOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function invlink(
     dist::MatrixOfUnivariate,
     x::AbstractMatrix{<:Real},
@@ -256,12 +261,24 @@ function logpdf_with_trans(
     end
 end
 function link(
+    dist::Union{MatrixOfUnivariate{Discrete}, VectorOfMultivariate{Discrete}},
+    x::AbstractArray{<:AbstractMatrix{<:Real}},
+)
+    return map(copy, x)
+end
+function link(
     dist::Union{MatrixOfUnivariate, VectorOfMultivariate},
     x::AbstractArray{<:AbstractMatrix{<:Real}},
 )
     map(x) do x
         link(dist, x)
     end
+end
+function invlink(
+    dist::Union{MatrixOfUnivariate{Discrete}, VectorOfMultivariate{Discrete}},
+    x::AbstractArray{<:AbstractMatrix{<:Real}},
+)
+    return map(copy, x)
 end
 function invlink(
     dist::Union{MatrixOfUnivariate, VectorOfMultivariate},

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -1,8 +1,9 @@
-using .DistributionsAD:
-    TuringDirichlet, TuringWishart, TuringInverseWishart, TuringScalMvNormal,
-    TuringDenseMvNormal, TuringDiagMvNormal,
-    FillVectorOfUnivariate, FillMatrixOfUnivariate, VectorOfUnivariate,
-    MatrixOfUnivariate, FillVectorOfMultivariate, VectorOfMultivariate
+using .DistributionsAD: TuringDirichlet, TuringWishart, TuringInverseWishart,
+                        FillVectorOfUnivariate, FillMatrixOfUnivariate,
+                        MatrixOfUnivariate, FillVectorOfMultivariate, VectorOfMultivariate,
+                        TuringScalMvNormal, TuringDiagMvNormal, TuringDenseMvNormal
+
+# Bijectors
 
 bijector(::TuringDirichlet) = SimplexBijector()
 bijector(::TuringWishart) = PDBijector()
@@ -10,11 +11,48 @@ bijector(::TuringInverseWishart) = PDBijector()
 bijector(::TuringScalMvNormal) = Identity{1}()
 bijector(::TuringDiagMvNormal) = Identity{1}()
 bijector(::TuringDenseMvNormal) = Identity{1}()
+# Fallback on link and invlink
+bijector(d::MatrixOfUnivariate) = DistributionBijector(d)
+bijector(d::VectorOfMultivariate) = DistributionBijector(d)
+
+# Non-Fill versions are not efficient for AD but are not used by Turing because we define 
+# logpdf_with_trans on the distributions directly
+function logabsdetjac(
+    b::DistributionBijector{<:Any, <:MatrixOfUnivariate},
+    x::AbstractMatrix{<:Real},
+)
+    return sum(logabsdetjac.(bijector.(b.dist.dists), x))
+end
+function logabsdetjac(
+    b::DistributionBijector{<:Any, <:VectorOfMultivariate},
+    x::AbstractMatrix{<:Real},
+)
+    return sumeachcol(x, b.dist.dists) do c, dist
+        logabsdetjac(bijector(dist), c)
+    end
+end
+function logabsdetjac(
+    b::DistributionBijector{<:Any, <:FillVectorOfUnivariate},
+    x::AbstractVector{<:Real},
+)
+    return sum(logabsdetjac(bijector(b.dist.dists.value), x))
+end
+function logabsdetjac(
+    b::DistributionBijector{<:Any, <:FillMatrixOfUnivariate},
+    x::AbstractMatrix{<:Real},
+)
+    return sum(logabsdetjac(bijector(b.dist.dists.value), x))
+end
+function logabsdetjac(
+    b::DistributionBijector{<:Any, <:FillVectorOfMultivariate},
+    x::AbstractMatrix{<:Real},
+)
+    return sum(logabsdetjac(bijector(b.dist.dists.value), x))
+end
+
+@register DistributionsAD.TuringUniform
 
 # TuringDirichlet
-
-_clamp(x, ::TuringDirichlet) = _clamp(x, SimplexBijector())
-bijector(d::TuringDirichlet) = SimplexBijector()
 
 function link(
     d::TuringDirichlet,
@@ -37,12 +75,7 @@ function logpdf_with_trans(
     x::AbstractVecOrMat{<:Real},
     transform::Bool,
 )
-    ϵ = _eps(eltype(x))
-    lp = logpdf(d, x .+ ϵ)
-    if transform
-        lp -= logabsdetjac(bijector(d), x)
-    end
-    return lp
+    return dirichlet_logpdf_with_trans(d, x, transform)
 end
 
 # TuringWishart
@@ -52,19 +85,17 @@ function logpdf_with_trans(
     X::AbstractMatrix{<:Real},
     transform::Bool
 )
-    return _logpdf_with_trans_pd(d, X, transform)
+    return pd_logpdf_with_trans(d, X, transform)
 end
 function logpdf_with_trans(
     d::TuringWishart,
     X::AbstractArray{<:AbstractMatrix{<:Real}},
     transform::Bool
 )
-    return mapvcat(X) do x
-        _logpdf_with_trans_pd(d, x, transform)
+    return map(X) do x
+        pd_logpdf_with_trans(d, x, transform)
     end
 end
-link(d::TuringWishart, X::AbstractMatrix{<:Real}) = PDBijector()(X)
-invlink(d::TuringWishart, Y::AbstractMatrix{<:Real}) = inv(PDBijector())(Y)
 function getlogp(d::TuringWishart, Xcf, X)
     return 0.5 * ((d.df - (dim(d) + 1)) * logdet(Xcf) - tr(d.chol \ X)) - d.c0
 end
@@ -76,19 +107,17 @@ function logpdf_with_trans(
     X::AbstractMatrix{<:Real},
     transform::Bool
 )
-    _logpdf_with_trans_pd(d, X, transform)
+    pd_logpdf_with_trans(d, X, transform)
 end
 function logpdf_with_trans(
     d::TuringInverseWishart,
     X::AbstractArray{<:AbstractMatrix{<:Real}},
     transform::Bool
 )
-    return mapvcat(X) do x
-        _logpdf_with_trans_pd(d, x, transform)
+    return map(X) do x
+        pd_logpdf_with_trans(d, x, transform)
     end
 end
-link(d::TuringInverseWishart, X::AbstractMatrix{<:Real}) = PDBijector()(X)
-invlink(d::TuringInverseWishart, Y::AbstractMatrix{<:Real}) = inv(PDBijector())(Y)
 function getlogp(d::TuringInverseWishart, Xcf, X)
     Ψ = d.S
     return -0.5 * ((d.df + dim(d) + 1) * logdet(Xcf) + tr(Xcf \ Ψ)) - d.c0
@@ -101,16 +130,9 @@ function logpdf_with_trans(
     x::AbstractVector{<:Real},
     istrans::Bool,
 )
-    return _sum(x) do x
+    return sum(map(x) do x
         logpdf_with_trans(dist.v.value, x, istrans)
-    end
-end
-function logpdf_with_trans(
-    dist::FillVectorOfUnivariate,
-    x::AbstractMatrix{<:Real},
-    istrans::Bool,
-)
-    return vec(sum(logpdf_with_trans(dist.v.value, x, istrans), dims = 1))
+    end)
 end
 function link(
     dist::FillVectorOfUnivariate,
@@ -118,21 +140,9 @@ function link(
 )
     return link(dist.v.value, x)
 end
-function link(
-    dist::FillVectorOfUnivariate,
-    x::AbstractMatrix{<:Real},
-)
-    return link(dist.v.value, x)
-end
 function invlink(
     dist::FillVectorOfUnivariate,
     x::AbstractVector{<:Real},
-)
-    return invlink(dist.v.value, x)
-end
-function invlink(
-    dist::FillVectorOfUnivariate,
-    x::AbstractMatrix{<:Real},
 )
     return invlink(dist.v.value, x)
 end
@@ -142,18 +152,9 @@ function logpdf_with_trans(
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
-    return _sum(x) do x
+    return sum(map(x) do x
         logpdf_with_trans(dist.dists.value, x, istrans)
-    end
-end
-function logpdf_with_trans(
-    dist::FillMatrixOfUnivariate,
-    x::AbstractArray{<:AbstractMatrix{<:Real}},
-    istrans::Bool,
-)
-    return mapvcat(x) do x
-        logpdf_with_trans(dist, x, istrans)
-    end
+    end)
 end
 function link(
     dist::FillMatrixOfUnivariate,
@@ -175,15 +176,6 @@ function logpdf_with_trans(
 )
     return sum(logpdf_with_trans(dist.dists.value, x, istrans))
 end
-function logpdf_with_trans(
-    dist::FillVectorOfMultivariate,
-    x::AbstractArray{<:AbstractMatrix{<:Real}},
-    istrans::Bool,
-)
-    return mapvcat(x) do x
-        logpdf_with_trans(dist, x, istrans)
-    end
-end
 function link(
     dist::FillVectorOfMultivariate,
     x::AbstractMatrix{<:Real},
@@ -202,7 +194,7 @@ function logpdf_with_trans(
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
-    return _sumeachcol(x, dist.dists) do c, dist
+    return sumeachcol(x, dist.dists) do c, dist
         logpdf_with_trans(dist, c, istrans)
     end
 end
@@ -211,7 +203,7 @@ function logpdf_with_trans(
     x::AbstractArray{<:AbstractMatrix{<:Real}},
     istrans::Bool,
 )
-    return mapvcat(x) do x
+    return map(x) do x
         logpdf_with_trans(dist, x, istrans)
     end
 end
@@ -233,89 +225,49 @@ function invlink(
 end
 
 function logpdf_with_trans(
-    dist::VectorOfUnivariate,
-    x::AbstractVector{<:Real},
-    istrans::Bool,
-)
-    return _sum(dist.v, x) do dist, x
-        logpdf_with_trans(dist, x, istrans)
-    end
-end
-function logpdf_with_trans(
-    dist::VectorOfUnivariate,
-    x::AbstractMatrix{<:Real},
-    istrans::Bool,
-)
-    return mapvcat(1:size(x,2)) do i
-        c = view(x, :, i)
-        sum(logpdf_with_trans.(dist.v, c, istrans))
-    end
-end
-function link(
-    dist::VectorOfUnivariate,
-    x::AbstractVector{<:Real},
-)
-    return mapvcat(dist.v, x) do dist, x
-        link(dist, x)
-    end
-end
-function link(
-    dist::VectorOfUnivariate,
-    x::AbstractMatrix{<:Real},
-)
-    return eachcolmaphcat(x) do x
-        link(dist, x)
-    end
-end
-
-function invlink(
-    dist::VectorOfUnivariate,
-    x::AbstractVector{<:Real},
-)
-    return mapvcat(dist.v, x) do dist, x
-        invlink(dist, x)
-    end
-end
-function invlink(
-    dist::VectorOfUnivariate,
-    x::AbstractMatrix{<:Real},
-)
-    return eachcolmaphcat(x) do x
-        invlink(dist, x)
-    end
-end
-
-function logpdf_with_trans(
     dist::MatrixOfUnivariate,
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
-    return _sum(dist.dists, x) do dist, x
+    return sum(maporbroadcast(dist.dists, x) do dist, x
         logpdf_with_trans(dist, x, istrans)
-    end
+    end)
 end
-function logpdf_with_trans(
+function link(
     dist::MatrixOfUnivariate,
+    x::AbstractMatrix{<:Real},
+)
+    return maporbroadcast(link, dist.dists, x)
+end
+function invlink(
+    dist::MatrixOfUnivariate,
+    x::AbstractMatrix{<:Real},
+)
+    return maporbroadcast(invlink, dist.dists, x)
+end
+
+function logpdf_with_trans(
+    dist::Union{MatrixOfUnivariate, VectorOfMultivariate},
     x::AbstractArray{<:AbstractMatrix{<:Real}},
     istrans::Bool,
 )
-    return mapvcat(x) do x
+    map(x) do x
         logpdf_with_trans(dist, x, istrans)
     end
 end
 function link(
-    dist::MatrixOfUnivariate,
-    x::AbstractMatrix{<:Real},
+    dist::Union{MatrixOfUnivariate, VectorOfMultivariate},
+    x::AbstractArray{<:AbstractMatrix{<:Real}},
 )
-    return mapvcat(dist.dists, x) do dist, x
+    map(x) do x
         link(dist, x)
     end
 end
 function invlink(
-    dist::MatrixOfUnivariate,
-    x::AbstractMatrix{<:Real},
+    dist::Union{MatrixOfUnivariate, VectorOfMultivariate},
+    x::AbstractArray{<:AbstractMatrix{<:Real}},
 )
-    return mapvcat(dist.dists, x) do dist, x
+    map(x) do x
         invlink(dist, x)
     end
 end

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -259,6 +259,24 @@ function link(
     end
 end
 
+function invlink(
+    dist::VectorOfUnivariate,
+    x::AbstractVector{<:Real},
+)
+    return mapvcat(dist.v, x) do dist, x
+        invlink(dist, x)
+    end
+end
+function invlink(
+    dist::VectorOfUnivariate,
+    x::AbstractMatrix{<:Real},
+)
+    return mapvcat(eachcol(x)) do x
+        invlink(dist, x)
+    end
+end
+
+
 function logpdf_with_trans(
     dist::MatrixOfUnivariate,
     x::AbstractMatrix{<:Real},

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -176,47 +176,76 @@ function invlink(
 end
 
 function logpdf_with_trans(
-    dist::FillMatrixOfUnivariate,
+    dist::FillMatrixOfUnivariate{Discrete},
+    x::AbstractMatrix{<:Real},
+    istrans::Bool,
+)
+    return logpdf(dist, x)
+end
+function logpdf_with_trans(
+    dist::FillMatrixOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
     return sum(logpdf_with_trans(dist.dists.value, x, istrans))
 end
+
+link(dist::FillMatrixOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
-    dist::FillMatrixOfUnivariate,
+    dist::FillMatrixOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return link(dist.dists.value, x)
 end
+
+invlink(dist::FillMatrixOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function invlink(
-    dist::FillMatrixOfUnivariate,
+    dist::FillMatrixOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return invlink(dist.dists.value, x)
 end
 
 function logpdf_with_trans(
-    dist::FillVectorOfMultivariate,
+    dist::FillVectorOfMultivariate{Discrete},
+    x::AbstractMatrix{<:Real},
+    istrans::Bool,
+)
+    return logpdf(dist, x)
+end
+function logpdf_with_trans(
+    dist::FillVectorOfMultivariate{Continuous},
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
     return sum(logpdf_with_trans(dist.dists.value, x, istrans))
 end
+
+link(dist::FillVectorOfMultivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
-    dist::FillVectorOfMultivariate,
+    dist::FillVectorOfMultivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return link(dist.dists.value, x)
 end
+
+invlink(dist::FillVectorOfMultivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function invlink(
-    dist::FillVectorOfMultivariate,
+    dist::FillVectorOfMultivariate{Continuous},
     x::AbstractMatrix{<:Real},
 )
     return invlink(dist.dists.value, x)
 end
 
 function logpdf_with_trans(
-    dist::VectorOfMultivariate,
+    dist::VectorOfMultivariate{Discrete},
+    x::AbstractMatrix{<:Real},
+    istrans::Bool,
+)
+    return logpdf(dist, x)
+end
+function logpdf_with_trans(
+    dist::VectorOfMultivariate{Continuous},
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
@@ -224,8 +253,16 @@ function logpdf_with_trans(
         logpdf_with_trans(dist, c, istrans)
     end
 end
+
 function logpdf_with_trans(
-    dist::VectorOfMultivariate,
+    dist::VectorOfMultivariate{Discrete},
+    x::AbstractArray{<:AbstractMatrix{<:Real}},
+    istrans::Bool,
+)
+    return logpdf(dist, x)
+end
+function logpdf_with_trans(
+    dist::VectorOfMultivariate{Continuous},
     x::AbstractArray{<:AbstractMatrix{<:Real}},
     istrans::Bool,
 )
@@ -254,7 +291,14 @@ function invlink(
 end
 
 function logpdf_with_trans(
-    dist::MatrixOfUnivariate,
+    dist::MatrixOfUnivariate{Discrete},
+    x::AbstractMatrix{<:Real},
+    istrans::Bool,
+)
+    return logpdf(dist, x)
+end
+function logpdf_with_trans(
+    dist::MatrixOfUnivariate{Continuous},
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
@@ -262,6 +306,7 @@ function logpdf_with_trans(
         logpdf_with_trans(dist, x, istrans)
     end)
 end
+
 link(dist::MatrixOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
     dist::MatrixOfUnivariate{Continuous},

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -132,8 +132,16 @@ function logpdf_with_trans(
 )
     return sum(logpdf_with_trans(dist.v.value, x, istrans))
 end
+function logpdf_with_trans(
+    dist::FillVectorOfUnivariate,
+    x::AbstractMatrix{<:Real},
+    istrans::Bool,
+)
+    return vec(sum(logpdf_with_trans(dist.v.value, x, istrans), dims = 1))
+end
 
 link(dist::FillVectorOfUnivariate{Discrete}, x::AbstractVector{<:Real}) = copy(x)
+link(dist::FillVectorOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function link(
     dist::FillVectorOfUnivariate{Continuous},
     x::AbstractVector{<:Real},
@@ -142,6 +150,7 @@ function link(
 end
 
 invlink(dist::FillVectorOfUnivariate{Discrete}, x::AbstractVector{<:Real}) = copy(x)
+invlink(dist::FillVectorOfUnivariate{Discrete}, x::AbstractMatrix{<:Real}) = copy(x)
 function invlink(
     dist::FillVectorOfUnivariate{Continuous},
     x::AbstractVector{<:Real},

--- a/src/compat/reversediff.jl
+++ b/src/compat/reversediff.jl
@@ -1,52 +1,181 @@
-const RTR = ReverseDiff.TrackedReal
-const RTV = ReverseDiff.TrackedVector
-const RTM = ReverseDiff.TrackedMatrix
-using .ReverseDiff: record_mul
-using .ReverseDiff: SpecialInstruction
+module ReverseDiffCompat
 
-_eps(::Type{<:RTR{T}}) where {T} = _eps(T)
+using ..ReverseDiff: ReverseDiff, @grad, value, track, TrackedReal, TrackedVector, 
+    TrackedMatrix
+using Requires, LinearAlgebra
 
-function replace_diag(::typeof(log), X::RTM{<:Any, D}) where {D}
-    tp = ReverseDiff.tape(X)
-    X_value = ReverseDiff.value(X)
-    f(i, j) = i == j ? log(X_value[i, j]) : X_value[i, j]
-    out_value = f.(1:size(X_value, 1), (1:size(X_value, 2))')
-    function back(∇)
-        g(i, j) = i == j ? ∇[i, j]/X_value[i, j] : ∇[i, j]
-        return g.(1:size(X_value, 1), (1:size(X_value, 2))')
+using ..Bijectors: Log, SimplexBijector, maphcat, simplex_link_jacobian, 
+    simplex_invlink_jacobian, simplex_logabsdetjac_gradient, ADBijector, 
+    ReverseDiffAD, Inverse
+import ..Bijectors: _eps, logabsdetjac, _logabsdetjac_scale, _simplex_bijector, 
+    _simplex_inv_bijector, replace_diag, jacobian, getpd, lower
+using Distributions: LocationScale
+
+# AD implementations
+function jacobian(
+    b::Union{<:ADBijector{<:ReverseDiffAD}, Inverse{<:ADBijector{<:ReverseDiffAD}}},
+    x::Real
+)
+    return ReverseDiff.gradient(x -> b(x[1]), [x])[1]
+end
+function jacobian(
+    b::Union{<:ADBijector{<:ReverseDiffAD}, Inverse{<:ADBijector{<:ReverseDiffAD}}},
+    x::AbstractVector{<:Real}
+)
+    return ReverseDiff.jacobian(b, x)
+end
+
+_eps(::Type{<:TrackedReal{T}}) where {T} = _eps(T)
+function Base.minimum(d::LocationScale{<:TrackedReal})
+    m = minimum(d.ρ)
+    if isfinite(m)
+        return d.μ + d.σ * m
+    else
+        return m
     end
-    out = ReverseDiff.track(out_value, D, tp)
-    ReverseDiff.record!(tp, ReverseDiff.SpecialInstruction, replace_diag, (log, X), out, (back,))
-    return out
 end
-
-function replace_diag(::typeof(exp), X::RTM{<:Any, D}) where {D}
-    tp = ReverseDiff.tape(X)
-    X_value = ReverseDiff.value(X)
-    f(i, j) = i == j ? exp(X_value[i, j]) : X_value[i, j]
-    out_value = f.(1:size(X_value, 1), (1:size(X_value, 2))')
-    function back(∇)
-        g(i, j) = i == j ? ∇[i, j]*exp(X_value[i, j]) : ∇[i, j]
-        return g.(1:size(X_value, 1), (1:size(X_value, 2))')
+function Base.maximum(d::LocationScale{<:TrackedReal})
+    m = maximum(d.ρ)
+    if isfinite(m)
+        return d.μ + d.σ * m
+    else
+        return m
     end
-    out = ReverseDiff.track(out_value, D, tp)
-    ReverseDiff.record!(tp, ReverseDiff.SpecialInstruction, replace_diag, (exp, X), out, (back,))
-    return out
 end
 
-@noinline function ReverseDiff.special_reverse_exec!(instruction::SpecialInstruction{typeof(replace_diag)})
-    output = instruction.output
-    input = instruction.input
-    input_deriv = ReverseDiff.deriv(input[2])
-    P = instruction.cache[1]
-    input_deriv .+= P(ReverseDiff.deriv(output))
-    ReverseDiff.unseed!(output)
-    return nothing
+logabsdetjac(b::Log{1}, x::Union{TrackedVector, TrackedMatrix}) = track(logabsdetjac, b, x)
+@grad function logabsdetjac(b::Log{1}, x::AbstractVector)
+    return -sum(log, value(x)), Δ -> (nothing, -Δ ./ value(x))
+end
+@grad function logabsdetjac(b::Log{1}, x::AbstractMatrix)
+    return -vec(sum(log, value(x); dims = 1)), Δ -> (nothing, .- Δ' ./ value(x))
+end
+function _logabsdetjac_scale(a::TrackedReal, x::Real, ::Val{0})
+    return track(_logabsdetjac_scale, a, value(x), Val(0))
+end
+@grad function _logabsdetjac_scale(a::Real, x::Real, v::Val{0})
+    return _logabsdetjac_scale(value(a), value(x), Val(0)), Δ -> (inv(value(a)) .* Δ, nothing, nothing)
+end
+# Need to treat `AbstractVector` and `AbstractMatrix` separately due to ambiguity errors
+function _logabsdetjac_scale(a::TrackedReal, x::AbstractVector, ::Val{0})
+    return track(_logabsdetjac_scale, a, value(x), Val(0))
+end
+@grad function _logabsdetjac_scale(a::Real, x::AbstractVector, v::Val{0})
+    da = value(a)
+    J = fill(inv.(da), length(x))
+    return _logabsdetjac_scale(da, value(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
+end
+function _logabsdetjac_scale(a::TrackedReal, x::AbstractMatrix, ::Val{0})
+    return track(_logabsdetjac_scale, a, value(x), Val(0))
+end
+@grad function _logabsdetjac_scale(a::Real, x::AbstractMatrix, v::Val{0})
+    da = value(a)
+    J = fill(size(x, 1) / da, size(x, 2))
+    return _logabsdetjac_scale(da, value(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
+end
+# adjoints for 1-dim and 2-dim `Scale` using `AbstractVector`
+function _logabsdetjac_scale(a::TrackedVector, x::AbstractVector, ::Val{1})
+    return track(_logabsdetjac_scale, a, value(x), Val(1))
+end
+@grad function _logabsdetjac_scale(a::TrackedVector, x::AbstractVector, v::Val{1})
+    # ∂ᵢ (∑ⱼ log|aⱼ|) = ∑ⱼ δᵢⱼ ∂ᵢ log|aⱼ|
+    #                 = ∂ᵢ log |aᵢ|
+    #                 = (1 / aᵢ) ∂ᵢ aᵢ
+    #                 = (1 / aᵢ)
+    da = value(a)
+    J = inv.(da)
+    return _logabsdetjac_scale(da, value(x), Val(1)), Δ -> (J .* Δ, nothing, nothing)
+end
+function _logabsdetjac_scale(a::TrackedVector, x::AbstractMatrix, ::Val{1})
+    return track(_logabsdetjac_scale, a, value(x), Val(1))
+end
+@grad function _logabsdetjac_scale(a::TrackedVector, x::AbstractMatrix, v::Val{1})
+    da = value(a)
+    Jᵀ = repeat(inv.(da), 1, size(x, 2))
+    return _logabsdetjac_scale(da, value(x), Val(1)), Δ -> (Jᵀ * Δ, nothing, nothing)
+end
+function _simplex_bijector(X::Union{TrackedVector, TrackedMatrix}, b::SimplexBijector)
+    return track(_simplex_bijector, X, b)
+end
+@grad function _simplex_bijector(Y::AbstractVector, b::SimplexBijector)
+    Yd = value(Y)
+    return _simplex_bijector(Yd, b), Δ -> (simplex_link_jacobian(Yd)' * Δ, nothing)
+end
+@grad function _simplex_bijector(Y::AbstractMatrix, b::SimplexBijector)
+    Yd = value(Y)
+    return _simplex_bijector(Yd, b), Δ -> begin
+        maphcat(eachcol(Yd), eachcol(Δ)) do c1, c2
+            simplex_link_jacobian(c1)' * c2
+        end, nothing
+    end
 end
 
-@noinline function ReverseDiff.special_forward_exec!(instruction::SpecialInstruction{typeof(replace_diag)})
-    output, input = instruction.output, instruction.input
-    out_value = replace_diag(ReverseDiff.value(input[1]), ReverseDiff.value(input[2]))
-    ReverseDiff.value!(output, out_value)
-    return nothing
+function _simplex_inv_bijector(X::Union{TrackedVector, TrackedMatrix}, b::SimplexBijector)
+    return track(_simplex_inv_bijector, X, b)
+end
+@grad function _simplex_inv_bijector(Y::AbstractVector, b::SimplexBijector)
+    Yd = value(Y)
+    return _simplex_inv_bijector(Yd, b), Δ -> (simplex_invlink_jacobian(Yd)' * Δ, nothing)
+end
+@grad function _simplex_inv_bijector(Y::AbstractMatrix, b::SimplexBijector)
+    Yd = value(Y)
+    return _simplex_inv_bijector(Yd, b), Δ -> begin
+        maphcat(eachcol(Yd), eachcol(Δ)) do c1, c2
+            simplex_invlink_jacobian(c1)' * c2
+        end, nothing
+    end
+end
+
+replace_diag(::typeof(log), X::TrackedMatrix) = track(replace_diag, log, X)
+@grad function replace_diag(::typeof(log), X)
+    Xd = value(X)
+    f(i, j) = i == j ? log(Xd[i, j]) : Xd[i, j]
+    out = f.(1:size(Xd, 1), (1:size(Xd, 2))')
+    out, ∇ -> begin
+        g(i, j) = i == j ? ∇[i, j]/Xd[i, j] : ∇[i, j]
+        return (nothing, g.(1:size(Xd, 1), (1:size(Xd, 2))'))
+    end
+end
+
+replace_diag(::typeof(exp), X::TrackedMatrix) = track(replace_diag, exp, X)
+@grad function replace_diag(::typeof(exp), X)
+    Xd = value(X)
+    f(i, j) = ifelse(i == j, exp(Xd[i, j]), Xd[i, j])
+    out = f.(1:size(Xd, 1), (1:size(Xd, 2))')
+    out, ∇ -> begin
+        g(i, j) = ifelse(i == j, ∇[i, j]*exp(Xd[i, j]), ∇[i, j])
+        return (nothing, g.(1:size(Xd, 1), (1:size(Xd, 2))'))
+    end
+end
+
+logabsdetjac(b::SimplexBijector, x::Union{TrackedVector, TrackedMatrix}) = track(logabsdetjac, b, x)
+@grad function logabsdetjac(b::SimplexBijector, x::AbstractVector)
+    xd = value(x)
+    return logabsdetjac(b, xd), Δ -> begin
+        (nothing, simplex_logabsdetjac_gradient(xd) * Δ)
+    end
+end
+@grad function logabsdetjac(b::SimplexBijector, x::AbstractMatrix)
+    xd = value(x)
+    return logabsdetjac(b, xd), Δ -> begin
+        (nothing, maphcat(eachcol(xd), Δ) do c, g
+            simplex_logabsdetjac_gradient(c) * g
+        end)
+    end
+end
+
+getpd(X::TrackedMatrix) = track(getpd, X)
+@grad function getpd(X::AbstractMatrix)
+    Xd = value(X)
+    return LowerTriangular(Xd) * LowerTriangular(Xd)', Δ -> begin
+        Xl = LowerTriangular(Xd)
+        return (LowerTriangular(Δ' * Xl + Δ * Xl),)
+    end
+end
+lower(A::TrackedMatrix) = track(lower, A)
+@grad function lower(A::AbstractMatrix)
+    Ad = value(A)
+    return lower(Ad), Δ -> (lower(Δ),)
+end
+
 end

--- a/src/compat/tracker.jl
+++ b/src/compat/tracker.jl
@@ -431,3 +431,11 @@ logabsdetjac(b::Log{1}, x::TrackedMatrix) = - vec(sum(log.(x); dims = 1))
 _logabsdetjac_shift(a::Real, x::TrackedVector{T}, ::Val{0}) where {T<:Real} = zeros(T, length(x))
 _logabsdetjac_shift(a::T1, x::TrackedVector{T2}, ::Val{1}) where {T1<:Union{Real, TrackedVector}, T2<:Real} = zero(T2)
 _logabsdetjac_shift(a::T1, x::TrackedMatrix{T2}, ::Val{1}) where {T1<:Union{Real, TrackedVector}, T2<:Real} = zeros(T2, size(x, 2))
+
+# `logabsdetjac` of `Identity` is just `zero(eltype)` with correct dimensionality.
+# But `eltype(::TrackedARray)` will result in a `Array{<:Tracker}`. So we just don't
+# propagate the gradient through it.
+function logabsdetjac(b::Identity{N}, x::TrackedArray) where {N}
+    # Un-track aan track so as to stay consistent with return-type
+    return Tracker.param(logabsdetjac(b, Tracker.data(x)))
+end

--- a/src/compat/tracker.jl
+++ b/src/compat/tracker.jl
@@ -1,4 +1,3 @@
-import .Tracker
 using .Tracker: Tracker,
                 TrackedReal,
                 TrackedVector,
@@ -11,54 +10,23 @@ using .Tracker: Tracker,
                 param
 using LinearAlgebra
 
-# Different from Tracker.istracked
-_istracked(x::AbstractArray{<:TrackedReal}) = true
-_istracked(::TrackedArray) = false
-
-Tracker.dual(x::Bool, p) = x
-Base.prevfloat(r::TrackedReal) = track(prevfloat, r)
-@grad function prevfloat(r::Real)
-    prevfloat(data(r)), Δ -> Δ
-end
-Base.nextfloat(r::TrackedReal) = track(nextfloat, r)
-@grad function nextfloat(r::Real)
-    nextfloat(data(r)), Δ -> Δ
-end
-for i = 0:2, c = Tracker.combinations([:AbstractArray, :TrackedArray, :TrackedReal, :Number], i), f = [:hcat, :vcat]
-    if :TrackedReal in c
-        cnames = map(_ -> gensym(), c)
-        @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Union{AbstractArray,Number}...) =
-            track($f, $(cnames...), x, xs...)
+_eps(::Type{<:TrackedReal{T}}) where {T} = _eps(T)
+function Base.minimum(d::LocationScale{<:TrackedReal})
+    m = minimum(d.ρ)
+    if isfinite(m)
+        return d.μ + d.σ * m
+    else
+        return m
     end
 end
-@grad function vcat(x::Real)
-    vcat(data(x)), (Δ) -> (Δ[1],)
+function Base.maximum(d::LocationScale{<:TrackedReal})
+    m = maximum(d.ρ)
+    if isfinite(m)
+        return d.μ + d.σ * m
+    else
+        return m
+    end
 end
-@grad function vcat(x1::Real, x2::Real)
-    vcat(data(x1), data(x2)), (Δ) -> (Δ[1], Δ[2])
-end
-@grad function vcat(x1::AbstractVector, x2::Real)
-    vcat(data(x1), data(x2)), (Δ) -> (Δ[1:length(x1)], Δ[length(x1)+1])
-end
-
-function Base.copy(
-    A::TrackedArray{T, 2, <:Adjoint{T, <:AbstractTriangular{T, <:AbstractMatrix{T}}}},
-) where {T <: Real}
-    return track(copy, A)
-end
-@grad function Base.copy(
-    A::TrackedArray{T, 2, <:Adjoint{T, <:AbstractTriangular{T, <:AbstractMatrix{T}}}},
-) where {T <: Real}
-    return copy(data(A)), ∇ -> (copy(∇),)
-end
-
-Base.:*(A::TrackedMatrix, B::AbstractTriangular) = track(*, A, B)
-Base.:*(A::AbstractTriangular{T}, B::TrackedVector) where {T} = track(*, A, B)
-Base.:*(A::AbstractTriangular{T}, B::TrackedMatrix) where {T} = track(*, A, B)
-Base.:*(A::Adjoint{T, <:AbstractTriangular{T}}, B::TrackedMatrix) where {T} = track(*, A, B)
-Base.:*(A::Adjoint{T, <:AbstractTriangular{T}}, B::TrackedVector) where {T} = track(*, A, B)
-
-_eps(::Type{<:TrackedReal{T}}) where {T} = _eps(T)
 
 # AD implementations
 function jacobian(
@@ -105,7 +73,6 @@ end
 @grad function logabsdetjac(b::Log{1}, x::AbstractMatrix)
     return -vec(sum(log, data(x); dims = 1)), Δ -> (nothing, .- Δ' ./ data(x))
 end
-
 # implementations for Scale bijector
 # Adjoints for 0-dim and 1-dim `Scale` using `Real`
 function _logabsdetjac_scale(a::TrackedReal, x::Real, ::Val{0})
@@ -159,10 +126,9 @@ end
 # @grad function _logabsdetjac_scale(a::TrackedMatrix, x::AbstractVector, ::Val{1})
 #     throw
 # end
-
 # implementations for Stacked bijector
 function logabsdetjac(b::Stacked, x::TrackedMatrix{<:Real})
-    return mapvcat(eachcol(x)) do c
+    return map(eachcol(x)) do c
         logabsdetjac(b, c)
     end
 end
@@ -170,16 +136,13 @@ end
 function (sb::Stacked)(x::TrackedMatrix{<:Real})
     return eachcolmaphcat(sb, x)
 end
-
 # Simplex adjoints
-
 function _simplex_bijector(X::TrackedVecOrMat, b::SimplexBijector)
     return track(_simplex_bijector, X, b)
 end
 function _simplex_inv_bijector(Y::TrackedVecOrMat, b::SimplexBijector)
     return track(_simplex_inv_bijector, Y, b)
 end
-
 @grad function _simplex_bijector(X::AbstractVector, b::SimplexBijector)
     Xd = data(X)
     return _simplex_bijector(Xd, b), Δ -> (simplex_link_jacobian(Xd)' * Δ, nothing)
@@ -432,10 +395,17 @@ _logabsdetjac_shift(a::Real, x::TrackedVector{T}, ::Val{0}) where {T<:Real} = ze
 _logabsdetjac_shift(a::T1, x::TrackedVector{T2}, ::Val{1}) where {T1<:Union{Real, TrackedVector}, T2<:Real} = zero(T2)
 _logabsdetjac_shift(a::T1, x::TrackedMatrix{T2}, ::Val{1}) where {T1<:Union{Real, TrackedVector}, T2<:Real} = zeros(T2, size(x, 2))
 
-# `logabsdetjac` of `Identity` is just `zero(eltype)` with correct dimensionality.
-# But `eltype(::TrackedARray)` will result in a `Array{<:Tracker}`. So we just don't
-# propagate the gradient through it.
-function logabsdetjac(b::Identity{N}, x::TrackedArray) where {N}
-    # Un-track aan track so as to stay consistent with return-type
-    return Tracker.param(logabsdetjac(b, Tracker.data(x)))
+getpd(X::TrackedMatrix) = track(getpd, X)
+@grad function getpd(X::AbstractMatrix)
+    Xd = data(X)
+    return LowerTriangular(Xd) * LowerTriangular(Xd)', Δ -> begin
+        Xl = LowerTriangular(Xd)
+        return (LowerTriangular(Δ' * Xl + Δ * Xl),)
+    end
+end
+
+lower(A::TrackedMatrix) = track(lower, A)
+@grad function lower(A::AbstractMatrix)
+    Ad = data(A)
+    return lower(Ad), Δ -> (lower(Δ),)
 end

--- a/src/compat/zygote.jl
+++ b/src/compat/zygote.jl
@@ -21,11 +21,7 @@ end
     end
     return pullback(g, f, x)
 end
-@adjoint function _sum(f, args...)
-    g(f, args...) = sum(map(f, args...))
-    return pullback(g, f, args...)
-end
-@adjoint function _sumeachcol(f, x1, x2)
+@adjoint function sumeachcol(f, x1, x2)
     g(f, x1, x2) = sum([f(view(x1, :, i), x2[i]) for i in 1:size(x1, 2)])
     return pullback(g, f, x1, x2)
 end
@@ -36,7 +32,6 @@ end
 @adjoint function logabsdetjac(b::Log{1}, x::AbstractMatrix)
     return -vec(sum(log, x; dims = 1)), Δ -> (nothing, .- Δ' ./ x)
 end
-
 # AD implementations
 function jacobian(
     b::Union{<:ADBijector{<:ZygoteAD}, Inverse{<:ADBijector{<:ZygoteAD}}},
@@ -73,9 +68,7 @@ end
     Jᵀ = repeat(inv.(a), 1, size(x, 2))
     return _logabsdetjac_scale(a, x, Val(1)), Δ -> (Jᵀ * Δ, nothing, nothing)
 end
-
 ## Positive definite matrices
-
 @adjoint function replace_diag(::typeof(log), X)
     f(i, j) = i == j ? log(X[i, j]) : X[i, j]
     out = f.(1:size(X, 1), (1:size(X, 2))')
@@ -93,14 +86,14 @@ end
     end
 end
 
-@adjoint function _logpdf_with_trans_pd(
+@adjoint function pd_logpdf_with_trans(
     d,
     X::AbstractMatrix{<:Real},
     transform::Bool,
 )
-    return pullback(_logpdf_with_trans_pd_zygote, d, X, transform)
+    return pullback(pd_logpdf_with_trans_zygote, d, X, transform)
 end
-function _logpdf_with_trans_pd_zygote(
+function pd_logpdf_with_trans_zygote(
     d,
     X::AbstractMatrix{<:Real},
     transform::Bool,
@@ -160,19 +153,40 @@ end
 
 # LocationScale fix
 
-@adjoint function _clamp(x::T, dist::LocationScale) where {T <: Real}
-    function f(x, dist)
-        ϵ = _eps(T)
-        bounds = (minimum(dist) + ϵ, maximum(dist) - ϵ)
-        if x < bounds[1]
-            clamped_x = bounds[1]
-        elseif x > bounds[2]
-            clamped_x = bounds[2]
+@adjoint function minimum(d::LocationScale)
+    function _minimum(d)
+        m = minimum(d.ρ)
+        if isfinite(m)
+            return d.μ + d.σ * m
         else
-            clamped_x = x
+            return m
         end
-        DEBUG && _debug("x = $x, bounds = $bounds, clamped_x = $clamped_x")
-        return clamped_x
     end
-    return pullback(f, x, dist)
+    return pullback(_minimum, d)
+end
+@adjoint function maximum(d::LocationScale)
+    function _maximum(d)
+        m = maximum(d.ρ)
+        if isfinite(m)
+            return d.μ + d.σ * m
+        else
+            return m
+        end
+    end
+    return pullback(_maximum, d)
+end
+@adjoint function lower(A::AbstractMatrix)
+    return lower(A), Δ -> (lower(Δ),)
+end
+@adjoint function getpd(X::AbstractMatrix)
+    return LowerTriangular(X) * LowerTriangular(X)', Δ -> begin
+        Xl = LowerTriangular(X)
+        return (LowerTriangular(Δ' * Xl + Δ * Xl),)
+    end
+end
+@adjoint function pd_link(X::AbstractMatrix{<:Real})
+    return pullback(X) do X
+        Y = cholesky(X; check = true).L
+        return replace_diag(log, Y)
+    end
 end

--- a/src/compat/zygote.jl
+++ b/src/compat/zygote.jl
@@ -32,6 +32,7 @@ end
 @adjoint function logabsdetjac(b::Log{1}, x::AbstractMatrix)
     return -vec(sum(log, x; dims = 1)), Δ -> (nothing, .- Δ' ./ x)
 end
+
 # AD implementations
 function jacobian(
     b::Union{<:ADBijector{<:ZygoteAD}, Inverse{<:ADBijector{<:ZygoteAD}}},

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -1,0 +1,76 @@
+macro register(dist)
+    return quote
+        Bijectors.eval(getexpr($(esc(dist))))
+        toflatten(::$(esc(dist))) = true
+    end
+end
+function getexpr(Tdist)
+    x = gensym(:x)
+    fnames = fieldnames(Tdist)
+    flattened_args = Expr(:tuple, [:(dist.$f) for f in fnames]...)
+    func = Expr(:->, 
+                Expr(:tuple, fnames..., x), 
+                Expr(:block,
+                    Expr(:call, :logpdf_with_trans,
+                        Expr(:call, :($Tdist), fnames...),
+                        x,
+                        :trans,
+                    )
+                )
+            )
+    return :(flatten(dist::$Tdist, trans) = ($func, $flattened_args))
+end
+const flattened_dists = [   Bernoulli,
+                            BetaBinomial,
+                            Binomial,
+                            Geometric,
+                            NegativeBinomial,
+                            Poisson,
+                            Skellam,
+                            Arcsine,
+                            Beta,
+                            BetaPrime,
+                            Biweight,
+                            Cauchy,
+                            Chernoff,
+                            Chi,
+                            Chisq,
+                            Cosine,
+                            Epanechnikov,
+                            Erlang,
+                            Exponential,
+                            FDist,
+                            Frechet,
+                            Gamma,
+                            GeneralizedExtremeValue,
+                            GeneralizedPareto,
+                            Gumbel,
+                            #InverseGamma,
+                            InverseGaussian,
+                            Kolmogorov,
+                            Laplace,
+                            Levy,
+                            LocationScale,
+                            Logistic,
+                            LogitNormal,
+                            LogNormal,
+                            Normal,
+                            #NormalCanon,
+                            #NormalInverseGaussian,
+                            Pareto,
+                            PGeneralizedGaussian,
+                            Rayleigh,
+                            SymTriangularDist,
+                            TDist,
+                            TriangularDist,
+                            Triweight,
+                            #Truncated,
+                            #VonMises,
+                        ]
+for T in flattened_dists
+    @eval toflatten(::$T) = true
+end
+toflatten(::Distribution) = false
+for T in flattened_dists
+    eval(getexpr(T))
+end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -105,7 +105,7 @@ logabsdetjacinv(b::Bijector, y) = logabsdetjac(inv(b), y)
 ##############################
 
 struct Identity{N} <: Bijector{N} end
-(::Identity)(x) = x
+(::Identity)(x) = copy(x)
 inv(b::Identity) = b
 
 logabsdetjac(::Identity, x::Real) = zero(eltype(x))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -9,19 +9,22 @@ import Distributions: logpdf, rand, rand!, _rand!, _logpdf
 
 abstract type ADBackend end
 struct ForwardDiffAD <: ADBackend end
+struct ReverseDiffAD <: ADBackend end
 struct TrackerAD <: ADBackend end
 struct ZygoteAD <: ADBackend end
 
-const ADBACKEND = Ref(:forward_diff)
+const ADBACKEND = Ref(:forwarddiff)
 setadbackend(backend_sym::Symbol) = setadbackend(Val(backend_sym))
-setadbackend(::Val{:forward_diff}) = ADBACKEND[] = :forward_diff
-setadbackend(::Val{:reverse_diff}) = ADBACKEND[] = :reverse_diff
+setadbackend(::Val{:forwarddiff}) = ADBACKEND[] = :forwarddiff
+setadbackend(::Val{:reversediff}) = ADBACKEND[] = :reversediff
+setadbackend(::Val{:tracker}) = ADBACKEND[] = :tracker
 setadbackend(::Val{:zygote}) = ADBACKEND[] = :zygote
 
 ADBackend() = ADBackend(ADBACKEND[])
 ADBackend(T::Symbol) = ADBackend(Val(T))
-ADBackend(::Val{:forward_diff}) = ForwardDiffAD
-ADBackend(::Val{:reverse_diff}) = TrackerAD
+ADBackend(::Val{:forwarddiff}) = ForwardDiffAD
+ADBackend(::Val{:reversediff}) = ReverseDiffAD
+ADBackend(::Val{:tracker}) = TrackerAD
 ADBackend(::Val{:zygote}) = ZygoteAD
 ADBackend(::Val) = error("The requested AD backend is not available. Make sure to load all required packages.")
 

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -36,7 +36,7 @@ Returns the constrained-to-unconstrained bijector for distribution `d`.
 bijector(d::DiscreteUnivariateDistribution) = Identity{0}()
 bijector(d::DiscreteMultivariateDistribution) = Identity{1}()
 bijector(d::ContinuousUnivariateDistribution) = TruncatedBijector(minimum(d), maximum(d))
-bijector(d::Distributions.Product) = stack(bijector.(d.v)...)
+bijector(d::Distributions.Product) = Stacked(bijector.(d.v))
 
 bijector(d::Normal) = Identity{0}()
 bijector(d::MvNormal) = Identity{1}()

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -34,11 +34,14 @@ transformed(d) = transformed(d, bijector(d))
 Returns the constrained-to-unconstrained bijector for distribution `d`.
 """
 bijector(d::DiscreteUnivariateDistribution) = Identity{0}()
+bijector(d::DiscreteMultivariateDistribution) = Identity{1}()
 bijector(d::ContinuousUnivariateDistribution) = TruncatedBijector(minimum(d), maximum(d))
 bijector(d::Distributions.Product) = stack(bijector.(d.v)...)
 
 bijector(d::Normal) = Identity{0}()
 bijector(d::MvNormal) = Identity{1}()
+bijector(d::MvNormalCanon) = Identity{1}()
+bijector(d::Distributions.AbstractMvLogNormal) = Log{1}()
 bijector(d::PositiveDistribution) = Log{0}()
 bijector(d::MvLogNormal) = Log{1}()
 bijector(d::SimplexDistribution) = SimplexBijector()
@@ -55,6 +58,8 @@ bijector(d::BoundedDistribution) = bijector_bounded(d)
 
 const LowerboundedDistribution = Union{Pareto, Levy}
 bijector(d::LowerboundedDistribution) = bijector_lowerbounded(d)
+
+bijector(d::PDMatDistribution) = PDBijector()
 
 
 ##############################

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -54,6 +54,8 @@ bijector(d::BoundedDistribution) = bijector_bounded(d)
 const LowerboundedDistribution = Union{Pareto, Levy}
 bijector(d::LowerboundedDistribution) = bijector_lowerbounded(d)
 
+bijector(d::Distributions.Product) = Stacked(bijector.(d.v))
+
 
 ##############################
 # Distributions.jl interface #

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -33,8 +33,9 @@ transformed(d) = transformed(d, bijector(d))
 
 Returns the constrained-to-unconstrained bijector for distribution `d`.
 """
-bijector(d::Distribution) = DistributionBijector(d)
-bijector(d::UnivariateDistribution) = TruncatedBijector(minimum(d), maximum(d))
+bijector(d::UnivariateDistribution) = Identity{0}()   # default to identity
+bijector(d::MultivariateDistribution) = Identity{1}() # default to identity
+bijector(d::MatrixDistribution) = Identity{2}()       # default to identity
 bijector(d::Normal) = Identity{0}()
 bijector(d::MvNormal) = Identity{1}()
 bijector(d::PositiveDistribution) = Log{0}()
@@ -54,7 +55,8 @@ bijector(d::BoundedDistribution) = bijector_bounded(d)
 const LowerboundedDistribution = Union{Pareto, Levy}
 bijector(d::LowerboundedDistribution) = bijector_lowerbounded(d)
 
-bijector(d::Distributions.Product) = Stacked(bijector.(d.v))
+bijector(d::TransformDistribution) = TruncatedBijector(minimum(d), maximum(d))
+bijector(d::Distributions.Product) = stack(bijector.(d.v)...)
 
 
 ##############################

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -33,9 +33,10 @@ transformed(d) = transformed(d, bijector(d))
 
 Returns the constrained-to-unconstrained bijector for distribution `d`.
 """
-bijector(d::UnivariateDistribution) = Identity{0}()   # default to identity
-bijector(d::MultivariateDistribution) = Identity{1}() # default to identity
-bijector(d::MatrixDistribution) = Identity{2}()       # default to identity
+bijector(d::DiscreteUnivariateDistribution) = Identity{0}()
+bijector(d::ContinuousUnivariateDistribution) = TruncatedBijector(minimum(d), maximum(d))
+bijector(d::Distributions.Product) = stack(bijector.(d.v)...)
+
 bijector(d::Normal) = Identity{0}()
 bijector(d::MvNormal) = Identity{1}()
 bijector(d::PositiveDistribution) = Log{0}()
@@ -54,9 +55,6 @@ bijector(d::BoundedDistribution) = bijector_bounded(d)
 
 const LowerboundedDistribution = Union{Pareto, Levy}
 bijector(d::LowerboundedDistribution) = bijector_lowerbounded(d)
-
-bijector(d::TransformDistribution) = TruncatedBijector(minimum(d), maximum(d))
-bijector(d::Distributions.Product) = stack(bijector.(d.v)...)
 
 
 ##############################

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -36,14 +36,14 @@ Returns the constrained-to-unconstrained bijector for distribution `d`.
 bijector(d::DiscreteUnivariateDistribution) = Identity{0}()
 bijector(d::DiscreteMultivariateDistribution) = Identity{1}()
 bijector(d::ContinuousUnivariateDistribution) = TruncatedBijector(minimum(d), maximum(d))
-bijector(d::Distributions.Product) = Stacked(bijector.(d.v))
+bijector(d::Distributions.Product{Discrete}) = Identity{1}()
+bijector(d::Distributions.Product{Continuous}) = DistributionBijector(d) # Use (inv)link
 
 bijector(d::Normal) = Identity{0}()
 bijector(d::MvNormal) = Identity{1}()
 bijector(d::MvNormalCanon) = Identity{1}()
 bijector(d::Distributions.AbstractMvLogNormal) = Log{1}()
 bijector(d::PositiveDistribution) = Log{0}()
-bijector(d::MvLogNormal) = Log{1}()
 bijector(d::SimplexDistribution) = SimplexBijector()
 bijector(d::KSOneSided) = Logit(zero(eltype(d)), one(eltype(d)))
 

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -60,6 +60,7 @@ const LowerboundedDistribution = Union{Pareto, Levy}
 bijector(d::LowerboundedDistribution) = bijector_lowerbounded(d)
 
 bijector(d::PDMatDistribution) = PDBijector()
+bijector(d::MatrixBeta) = PDBijector()
 
 
 ##############################

--- a/test/ad/ad_test_utils.jl
+++ b/test/ad/ad_test_utils.jl
@@ -76,8 +76,8 @@ function get_function(dist::DistSpec, inds, val)
                 temp_args = ($(args...),)
                 temp_dist = $(dist.name)(temp_args...)
                 temp_x = $(sym)
-                link(temp_dist, temp_x)
-                temp = logpdf_with_trans(temp_dist, invlink(temp_dist, temp_x), true)
+                temp_y = link(temp_dist, temp_x)
+                temp = logpdf_with_trans(temp_dist, invlink(temp_dist, temp_y), true)
                 if temp isa AbstractVector
                     return sum(temp)
                 else
@@ -99,8 +99,8 @@ function get_function(dist::DistSpec, inds, val)
                 temp_args = ($(args...),)
                 temp_dist = $(dist.name)(temp_args...)
                 temp_x = $(dist.x)
-                link(temp_dist, temp_x)
-                temp = logpdf_with_trans(temp_dist, invlink(temp_dist, temp_x), true)
+                temp_y = link(temp_dist, temp_x)
+                temp = logpdf_with_trans(temp_dist, invlink(temp_dist, temp_y), true)
                 if temp isa AbstractVector
                     return sum(temp)
                 else

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -498,6 +498,11 @@
             for testf in get_all_functions(d, false)
                 test_ad(testf.f, testf.x)
             end
+
+            dist = @eval :($(d.name)(d.θ...))
+            x = d.x
+            y = link(dist, x)
+            @test invlink(dist, y) ≈ x
         end
     end
     separator()
@@ -514,6 +519,16 @@
             for testf in get_all_functions(d, true)
                 test_ad(testf.f, testf.x)
             end
+
+            dist = eval(:($(d.name)($(d.θ)...)))
+            x = d.x
+            y = link(dist, x)
+            @test invlink(dist, y) ≈ x
+
+            # if the transform is non-identity => verify that forward map is different
+            if !(bijector(dist) isa Identity)
+                @test x ≠ y
+            end
         end
     end
     separator()
@@ -524,6 +539,16 @@
             test_info(d.name)
             for testf in get_all_functions(d, false)
                 test_ad(testf.f, testf.x)
+            end
+
+            dist = eval(:($(d.name)($(d.θ)...)))
+            x = d.x
+            y = link(dist, x)
+            @test all(invlink(dist, y) .≈ x)
+
+            # if the transform is non-identity => verify that forward map is different
+            if !(bijector(dist) isa Identity)
+                @test all(x .≠ y)
             end
         end
     end
@@ -536,6 +561,16 @@
             for testf in get_all_functions(d, true)
                 test_ad(testf.f, testf.x)
             end
+
+            dist = eval(:($(d.name)($(d.θ)...)))
+            x = d.x
+            y = link(dist, x)
+            @test all(invlink(dist, y) .≈ x)
+
+            # if the transform is non-identity => verify that forward map is different
+            if !(bijector(dist) isa Identity)
+                @test all(x .≠ y)
+            end
         end
     end
     separator()
@@ -546,6 +581,16 @@
             test_info(d.name)
             for testf in get_all_functions(d, true)
                 test_ad(testf.f, testf.x)
+            end
+
+            dist = eval(:($(d.name)($(d.θ)...)))
+            x = d.x
+            y = link(dist, x)
+            @test all(invlink(dist, y) .≈ x)
+
+            # if the transform is non-identity => verify that forward map is different
+            if !(bijector(dist) isa Identity)
+                @test all(x .≠ y)
             end
         end
     end

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -1,3 +1,5 @@
+short_tests = false
+
 @testset "AD tests" begin
     ddim = 3
     dmean = zeros(ddim)
@@ -336,6 +338,9 @@
         #DistSpec(:Weibull, (1.0,), [1.0]),
         #DistSpec(:Weibull, (1.0, 1.0), [1.0]),
     ]
+    if short_tests
+        uni_cont_dists = uni_cont_dists[1:10]
+    end
     broken_uni_cont_dists = [
         # Zygote
         DistSpec(:Chernoff, (), 0.5),
@@ -417,6 +422,9 @@
 
         DistSpec(:Dirichlet, (alpha,), dir_val_mat),
     ]
+    if short_tests
+        multi_cont_dists = multi_cont_dists[1:10]
+    end
     xmulti_cont_dists = [
         # Vector x
         filter(!isnothing, filldist_spec.(uni_cont_dists; n = 2, d = 1));

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -499,7 +499,7 @@
                 test_ad(testf.f, testf.x)
             end
 
-            dist = @eval :($(d.name)(d.θ...))
+            dist = eval(:($(d.name)($(d.θ)...)))
             x = d.x
             y = link(dist, x)
             @test invlink(dist, y) ≈ x
@@ -524,11 +524,6 @@
             x = d.x
             y = link(dist, x)
             @test invlink(dist, y) ≈ x
-
-            # if the transform is non-identity => verify that forward map is different
-            if !(bijector(dist) isa Identity)
-                @test x ≠ y
-            end
         end
     end
     separator()
@@ -545,11 +540,6 @@
             x = d.x
             y = link(dist, x)
             @test all(invlink(dist, y) .≈ x)
-
-            # if the transform is non-identity => verify that forward map is different
-            if !(bijector(dist) isa Identity)
-                @test all(x .≠ y)
-            end
         end
     end
 
@@ -566,11 +556,6 @@
             x = d.x
             y = link(dist, x)
             @test all(invlink(dist, y) .≈ x)
-
-            # if the transform is non-identity => verify that forward map is different
-            if !(bijector(dist) isa Identity)
-                @test all(x .≠ y)
-            end
         end
     end
     separator()
@@ -587,11 +572,6 @@
             x = d.x
             y = link(dist, x)
             @test all(invlink(dist, y) .≈ x)
-
-            # if the transform is non-identity => verify that forward map is different
-            if !(bijector(dist) isa Identity)
-                @test all(x .≠ y)
-            end
         end
     end
     separator()

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -101,7 +101,7 @@ end
 
         @testset "$dist: ForwardDiff AD" begin
             x = rand(dist)
-            b = DistributionBijector{Bijectors.ADBackend(:forward_diff), typeof(dist), length(size(dist))}(dist)
+            b = DistributionBijector{Bijectors.ADBackend(:forwarddiff), typeof(dist), length(size(dist))}(dist)
             
             @test abs(det(Bijectors.jacobian(b, x))) > 0
             @test logabsdetjac(b, x) ≠ Inf
@@ -114,7 +114,7 @@ end
 
         @testset "$dist: Tracker AD" begin
             x = rand(dist)
-            b = DistributionBijector{Bijectors.ADBackend(:reverse_diff), typeof(dist), length(size(dist))}(dist)
+            b = DistributionBijector{Bijectors.ADBackend(:reversediff), typeof(dist), length(size(dist))}(dist)
             
             @test abs(det(Bijectors.jacobian(b, x))) > 0
             @test logabsdetjac(b, x) ≠ Inf
@@ -163,11 +163,11 @@ end
             y = @inferred b(x)
 
             ys = @inferred b(xs)
-            @test @inferred(b(param(xs))) isa TrackedArray
+            @inferred(b(param(xs)))
 
             x_ = @inferred ib(y)
             xs_ = @inferred ib(ys)
-            @test @inferred(ib(param(ys))) isa TrackedArray
+            @inferred(ib(param(ys)))
 
             result = @inferred forward(b, x)
             results = @inferred forward(b, xs)
@@ -505,8 +505,8 @@ end
     b1 = DistributionBijector(d)
     b2 = DistributionBijector(Gamma())
 
-    cb = b1 ∘ b2
-    @test cb(x) ≈ b1(b2(x))
+    cb = inv(b1) ∘ b2
+    @test cb(x) ≈ inv(b1)(b2(x))
 
     # contrived example
     b = bijector(d)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Tracker, ForwardDiff, Zygote, DistributionsAD, Bijectors, ReverseDiff
+using ReverseDiff, Tracker, ForwardDiff, Zygote, DistributionsAD, Bijectors
 using Random, LinearAlgebra, Combinatorics, Test
 using DistributionsAD: TuringUniform, TuringMvNormal, TuringMvLogNormal, 
                         TuringPoissonBinomial

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,9 +12,13 @@ function get_stage()
         else
             return "nonAD"
         end
+    else
+        if "STAGE" in keys(ENV)
+            return ENV["STAGE"]
+        else
+            return "all"
+        end
     end
-
-    return "all"
 end
 
 stg = get_stage()


### PR DESCRIPTION
Making it a bit easier to override default `link` etc. using `bijector`, e.g. to fix #93 we just need
```julia
bijector(d::Distributions.Product) = stack(bijector.(d.vs)...) # or Stacked(bijector.(d.vs))
```
by replacing the default impls of `link`, `invlink` and `logpdf_with_trans` with impls using `bijector(d)` under the hood. 

Will help to stop issues like #100 occurring in the future :+1:

NB: At the moment some AD tests are failing! Trying to figure out why but help would be appreciated.