### PR TITLE
AD perf fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,13 +536,13 @@ struct Logit{T<:Real} <: Bijector{0}
 end
 
 (b::Logit)(x::Real) = logit((x - b.a) / (b.b - b.a))
-(b::Logit)(x) = mapvcat(b, x)
+(b::Logit)(x) = map(b, x)
 # `orig` contains the `Bijector` which was inverted
 (ib::Inverse{<:Logit})(y::Real) = (ib.orig.b - ib.orig.a) * logistic(y) + ib.orig.a
-(ib::Inverse{<:Logit})(y) = mapvcat(ib, y)
+(ib::Inverse{<:Logit})(y) = map(ib, y)
 
 logabsdetjac(b::Logit, x::Real) = - log((x - b.a) * (b.b - x) / (b.b - b.a))
-logabsdetjac(b::Logit, x) = mapvcat(logabsdetjac, x)
+logabsdetjac(b::Logit, x) = map(logabsdetjac, x)
 ```
 
 (Batch computation is not fully supported by all bijectors yet (see issue #35), but is actively worked on. In the particular case of `Logit` there's only one thing that makes sense, which is elementwise application. Therefore we've added `@.` to the implementation above, thus this works for any `AbstractArray{<:Real}`.)

--- a/src/bijectors/logit.jl
+++ b/src/bijectors/logit.jl
@@ -8,13 +8,14 @@ struct Logit{T<:Real} <: Bijector{0}
     b::T
 end
 
-(b::Logit)(x::Real) = logit((x - b.a) / (b.b - b.a))
-(b::Logit)(x) = mapvcat(b, x)
+(b::Logit)(x::Real) = _logit(x, b.a, b.b)
+(b::Logit)(x) = _logit.(x, b.a, b.b)
+_logit(x, a, b) = logit((x - a) / (b - a))
 
-(ib::Inverse{<:Logit})(y::Real) = (ib.orig.b - ib.orig.a) * logistic(y) + ib.orig.a
-(ib::Inverse{<:Logit})(y) = mapvcat(ib, y)
+(ib::Inverse{<:Logit})(y::Real) = _ilogit(y, ib.orig.a, ib.orig.b)
+(ib::Inverse{<:Logit})(y) = _ilogit.(y, ib.orig.a, ib.orig.b)
+_ilogit(y, a, b) = (b - a) * logistic(y) + a
 
-logabsdetjac(b::Logit, x::Real) = -log((x - b.a) * (b.b - x) / (b.b - b.a))
-logabsdetjac(b::Logit, x) = mapvcat(x) do x
-    logabsdetjac(b, x)
-end
+logabsdetjac(b::Logit, x::Real) = logit_logabsdetjac(x, b.a, b.b)
+logabsdetjac(b::Logit, x) = logit_logabsdetjac.(x, b.a, b.b)
+logit_logabsdetjac(x, a, b) = -log((x - a) * (b - x) / (b - a))

--- a/src/bijectors/stacked.jl
+++ b/src/bijectors/stacked.jl
@@ -78,7 +78,7 @@ function (sb::Stacked{<:Tuple})(x::AbstractVector{<:Real})
 end
 # The Stacked{<:AbstractArray} version is not TrackedArray friendly
 function (sb::Stacked{<:AbstractArray, N})(x::AbstractVector{<:Real}) where {N}
-    y = mapvcat2(1:N) do i
+    y = mapvcat(1:N) do i
         sb.bs[i](x[sb.ranges[i]])
     end
     @assert size(y) == size(x) "x is size $(size(x)) but y is $(size(y))"
@@ -97,7 +97,7 @@ function logabsdetjac(
 end
 
 function logabsdetjac(b::Stacked, x::AbstractMatrix{<:Real})
-    return mapvcat(eachcol(x)) do c
+    return map(eachcol(x)) do c
         logabsdetjac(b, c)
     end
 end
@@ -136,7 +136,7 @@ end
 function forward(sb::Stacked{<:AbstractArray, N}, x::AbstractVector) where {N}
     yinit, linit = forward(sb.bs[1], x[sb.ranges[1]])
     logjac = sum(linit)
-    ys = mapvcat2(drop(sb.bs, 1), drop(sb.ranges, 1)) do b, r
+    ys = mapvcat(drop(sb.bs, 1), drop(sb.ranges, 1)) do b, r
         y, l = forward(b, x[r])
         logjac += sum(l)
         y

--- a/src/compat/distributionsad.jl
+++ b/src/compat/distributionsad.jl
@@ -178,47 +178,28 @@ function invlink(
     end
 end
 
+using .DistributionsAD: maporbroadcast
+
 function logpdf_with_trans(
     dist::VectorOfUnivariate,
     x::AbstractVector{<:Real},
     istrans::Bool,
 )
-    return map(dist.v, x) do dist, x
-        logpdf_with_trans(dist, x, istrans)
-    end |> sum
+    return maporbroadcast(dist.v, x) do d, x
+        logpdf_with_trans(d, x, istrans)
+    end
 end
 function link(
     dist::VectorOfUnivariate,
     x::AbstractVector{<:Real},
 )
-    return map(dist.v, x) do dist, x
-        link(dist, x)
-    end
+    return maporbroadcast(link, dist.v, x)
 end
 function invlink(
     dist::VectorOfUnivariate,
     x::AbstractVector{<:Real},
 )
-    return map(dist.v, x) do dist, x
-        invlink(dist, x)
-    end
-end
-
-function invlink(
-    dist::VectorOfUnivariate,
-    x::AbstractVector{<:Real},
-)
-    return mapvcat(dist.v, x) do dist, x
-        invlink(dist, x)
-    end
-end
-function invlink(
-    dist::VectorOfUnivariate,
-    x::AbstractMatrix{<:Real},
-)
-    return eachcolmaphcat(x) do x
-        invlink(dist, x)
-    end
+    return maporbroadcast(invlink, dist.v, x)
 end
 
 function logpdf_with_trans(
@@ -226,7 +207,7 @@ function logpdf_with_trans(
     x::AbstractMatrix{<:Real},
     istrans::Bool,
 )
-    return map(dist.dists, x) do dist, x
+    return maporbroadcast(dist.dists, x) do dist, x
         logpdf_with_trans(dist, x, istrans)
     end |> sum
 end
@@ -234,15 +215,11 @@ function link(
     dist::MatrixOfUnivariate,
     x::AbstractMatrix{<:Real},
 )
-    return map(dist.dists, x) do dist, x
-        link(dist, x)
-    end
+    return maporbroadcast(link, dist.dists, x)
 end
 function invlink(
     dist::MatrixOfUnivariate,
     x::AbstractMatrix{<:Real},
 )
-    return map(dist.dists, x) do dist, x
-        invlink(dist, x)
-    end
+    return maporbroadcast(invlink, dist.dists, x)
 end

--- a/src/compat/reversediff.jl
+++ b/src/compat/reversediff.jl
@@ -1,52 +1,174 @@
+module ReverseDiffCompat
+
+using ..ReverseDiff: ReverseDiff, value, deriv, track, SpecialInstruction
+using Requires, LinearAlgebra
 const RTR = ReverseDiff.TrackedReal
 const RTV = ReverseDiff.TrackedVector
 const RTM = ReverseDiff.TrackedMatrix
-using .ReverseDiff: record_mul
-using .ReverseDiff: SpecialInstruction
+const RTA = ReverseDiff.TrackedArray
+
+import Base: vcat, hcat
+using ..Bijectors: Log, SimplexBijector, maphcat, simplex_link_jacobian, 
+    simplex_invlink_jacobian, simplex_logabsdetjac_gradient
+import ..Bijectors: _eps, logabsdetjac, _logabsdetjac_scale, _simplex_bijector, 
+    _simplex_inv_bijector, replace_diag
 
 _eps(::Type{<:RTR{T}}) where {T} = _eps(T)
 
-function replace_diag(::typeof(log), X::RTM{<:Any, D}) where {D}
-    tp = ReverseDiff.tape(X)
-    X_value = ReverseDiff.value(X)
-    f(i, j) = i == j ? log(X_value[i, j]) : X_value[i, j]
-    out_value = f.(1:size(X_value, 1), (1:size(X_value, 2))')
-    function back(∇)
-        g(i, j) = i == j ? ∇[i, j]/X_value[i, j] : ∇[i, j]
-        return g.(1:size(X_value, 1), (1:size(X_value, 2))')
+expr = Expr(:block)
+combs = [
+    [],
+    [:AbstractArray],
+    [:RTA],
+    [:RTR],
+    [:Number],
+    [:AbstractArray, :RTA],
+    [:AbstractArray, :RTR],
+    [:AbstractArray, :Number],
+    [:RTA, :RTR],
+    [:RTA, :Number],
+]
+for c in combs, f = [:hcat, :vcat]
+    cnames = map(_ -> gensym(), c)
+    push!(expr.args, :(Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{RTA, RTR}, xs::Union{AbstractArray, Number}...) = track($f, $(cnames...), x, xs...)))
+end
+using DistributionsAD
+#=@init @require DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c"=# @eval begin
+    $expr
+    DistributionsAD.ReverseDiffX.@grad function vcat(x::Real)
+        vcat(value(x)), (Δ) -> (Δ[1],)
     end
-    out = ReverseDiff.track(out_value, D, tp)
-    ReverseDiff.record!(tp, ReverseDiff.SpecialInstruction, replace_diag, (log, X), out, (back,))
-    return out
-end
-
-function replace_diag(::typeof(exp), X::RTM{<:Any, D}) where {D}
-    tp = ReverseDiff.tape(X)
-    X_value = ReverseDiff.value(X)
-    f(i, j) = i == j ? exp(X_value[i, j]) : X_value[i, j]
-    out_value = f.(1:size(X_value, 1), (1:size(X_value, 2))')
-    function back(∇)
-        g(i, j) = i == j ? ∇[i, j]*exp(X_value[i, j]) : ∇[i, j]
-        return g.(1:size(X_value, 1), (1:size(X_value, 2))')
+    DistributionsAD.ReverseDiffX.@grad function vcat(x1::Real, x2::Real)
+        vcat(value(x1), value(x2)), (Δ) -> (Δ[1], Δ[2])
     end
-    out = ReverseDiff.track(out_value, D, tp)
-    ReverseDiff.record!(tp, ReverseDiff.SpecialInstruction, replace_diag, (exp, X), out, (back,))
-    return out
+    DistributionsAD.ReverseDiffX.@grad function vcat(x1::AbstractVector, x2::Real)
+        vcat(value(x1), value(x2)), (Δ) -> (Δ[1:length(x1)], Δ[length(x1)+1])
+    end
+
+    logabsdetjac(b::Log{1}, x::Union{RTV, RTM}) = track(logabsdetjac, b, x)
+    DistributionsAD.ReverseDiffX.@grad function logabsdetjac(b::Log{1}, x::AbstractVector)
+        return -sum(log, value(x)), Δ -> (nothing, -Δ ./ value(x))
+    end
+    DistributionsAD.ReverseDiffX.@grad function logabsdetjac(b::Log{1}, x::AbstractMatrix)
+        return -vec(sum(log, value(x); dims = 1)), Δ -> (nothing, .- Δ' ./ value(x))
+    end
+
+    function _logabsdetjac_scale(a::RTR, x::Real, ::Val{0})
+        return track(_logabsdetjac_scale, a, value(x), Val(0))
+    end
+    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::Real, x::Real, v::Val{0})
+        return _logabsdetjac_scale(value(a), value(x), Val(0)), Δ -> (inv(value(a)) .* Δ, nothing, nothing)
+    end
+    # Need to treat `AbstractVector` and `AbstractMatrix` separately due to ambiguity errors
+    function _logabsdetjac_scale(a::RTR, x::AbstractVector, ::Val{0})
+        return track(_logabsdetjac_scale, a, value(x), Val(0))
+    end
+    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::Real, x::AbstractVector, v::Val{0})
+        da = value(a)
+        J = fill(inv.(da), length(x))
+        return _logabsdetjac_scale(da, value(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
+    end
+    function _logabsdetjac_scale(a::RTR, x::AbstractMatrix, ::Val{0})
+        return track(_logabsdetjac_scale, a, value(x), Val(0))
+    end
+    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::Real, x::AbstractMatrix, v::Val{0})
+        da = value(a)
+        J = fill(size(x, 1) / da, size(x, 2))
+        return _logabsdetjac_scale(da, value(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
+    end
+    # adjoints for 1-dim and 2-dim `Scale` using `AbstractVector`
+    function _logabsdetjac_scale(a::RTV, x::AbstractVector, ::Val{1})
+        return track(_logabsdetjac_scale, a, value(x), Val(1))
+    end
+    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::RTV, x::AbstractVector, v::Val{1})
+        # ∂ᵢ (∑ⱼ log|aⱼ|) = ∑ⱼ δᵢⱼ ∂ᵢ log|aⱼ|
+        #                 = ∂ᵢ log |aᵢ|
+        #                 = (1 / aᵢ) ∂ᵢ aᵢ
+        #                 = (1 / aᵢ)
+        da = value(a)
+        J = inv.(da)
+        return _logabsdetjac_scale(da, value(x), Val(1)), Δ -> (J .* Δ, nothing, nothing)
+    end
+    function _logabsdetjac_scale(a::RTV, x::AbstractMatrix, ::Val{1})
+        return track(_logabsdetjac_scale, a, value(x), Val(1))
+    end
+    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::RTV, x::AbstractMatrix, v::Val{1})
+        da = value(a)
+        Jᵀ = repeat(inv.(da), 1, size(x, 2))
+        return _logabsdetjac_scale(da, value(x), Val(1)), Δ -> (Jᵀ * Δ, nothing, nothing)
+    end
+
+    function _simplex_bijector(X::Union{RTV, RTM}, b::SimplexBijector)
+        return track(_simplex_bijector, X, b)
+    end
+    DistributionsAD.ReverseDiffX.@grad function _simplex_bijector(Y::AbstractVector, b::SimplexBijector)
+        Yd = value(Y)
+        return _simplex_bijector(Yd, b), Δ -> (simplex_link_jacobian(Yd)' * Δ, nothing)
+    end
+    DistributionsAD.ReverseDiffX.@grad function _simplex_bijector(Y::AbstractMatrix, b::SimplexBijector)
+        Yd = value(Y)
+        return _simplex_bijector(Yd, b), Δ -> begin
+            maphcat(eachcol(Yd), eachcol(Δ)) do c1, c2
+                simplex_link_jacobian(c1)' * c2
+            end, nothing
+        end
+    end
+
+    function _simplex_inv_bijector(X::Union{RTV, RTM}, b::SimplexBijector)
+        return track(_simplex_inv_bijector, X, b)
+    end
+    DistributionsAD.ReverseDiffX.@grad function _simplex_inv_bijector(Y::AbstractVector, b::SimplexBijector)
+        Yd = value(Y)
+        return _simplex_inv_bijector(Yd, b), Δ -> (simplex_invlink_jacobian(Yd)' * Δ, nothing)
+    end
+    DistributionsAD.ReverseDiffX.@grad function _simplex_inv_bijector(Y::AbstractMatrix, b::SimplexBijector)
+        Yd = value(Y)
+        return _simplex_inv_bijector(Yd, b), Δ -> begin
+            maphcat(eachcol(Yd), eachcol(Δ)) do c1, c2
+                simplex_invlink_jacobian(c1)' * c2
+            end, nothing
+        end
+    end
+
+    replace_diag(::typeof(log), X::RTM) = track(replace_diag, log, X)
+    DistributionsAD.ReverseDiffX.@grad function replace_diag(::typeof(log), X)
+        Xd = value(X)
+        f(i, j) = i == j ? log(Xd[i, j]) : Xd[i, j]
+        out = f.(1:size(Xd, 1), (1:size(Xd, 2))')
+        out, ∇ -> begin
+            g(i, j) = i == j ? ∇[i, j]/Xd[i, j] : ∇[i, j]
+            return (nothing, g.(1:size(Xd, 1), (1:size(Xd, 2))'))
+        end
+    end
+
+    replace_diag(::typeof(exp), X::RTM) = track(replace_diag, exp, X)
+    DistributionsAD.ReverseDiffX.@grad function replace_diag(::typeof(exp), X)
+        Xd = value(X)
+        f(i, j) = ifelse(i == j, exp(Xd[i, j]), Xd[i, j])
+        out = f.(1:size(Xd, 1), (1:size(Xd, 2))')
+        out, ∇ -> begin
+            g(i, j) = ifelse(i == j, ∇[i, j]*exp(Xd[i, j]), ∇[i, j])
+            return (nothing, g.(1:size(Xd, 1), (1:size(Xd, 2))'))
+        end
+    end
+
+    logabsdetjac(b::SimplexBijector, x::Union{RTV, RTM}) = track(logabsdetjac, b, x)
+    DistributionsAD.ReverseDiffX.@grad function logabsdetjac(b::SimplexBijector, x::AbstractVector)
+        xd = value(x)
+        return logabsdetjac(b, xd), Δ -> begin
+            (nothing, simplex_logabsdetjac_gradient(xd) * Δ)
+        end
+    end
+    DistributionsAD.ReverseDiffX.@grad function logabsdetjac(b::SimplexBijector, x::AbstractMatrix)
+        xd = value(x)
+        return logabsdetjac(b, xd), Δ -> begin
+            (nothing, maphcat(eachcol(xd), Δ) do c, g
+                simplex_logabsdetjac_gradient(c) * g
+            end)
+        end
+    end
 end
 
-@noinline function ReverseDiff.special_reverse_exec!(instruction::SpecialInstruction{typeof(replace_diag)})
-    output = instruction.output
-    input = instruction.input
-    input_deriv = ReverseDiff.deriv(input[2])
-    P = instruction.cache[1]
-    input_deriv .+= P(ReverseDiff.deriv(output))
-    ReverseDiff.unseed!(output)
-    return nothing
 end
 
-@noinline function ReverseDiff.special_forward_exec!(instruction::SpecialInstruction{typeof(replace_diag)})
-    output, input = instruction.output, instruction.input
-    out_value = replace_diag(ReverseDiff.value(input[1]), ReverseDiff.value(input[2]))
-    ReverseDiff.value!(output, out_value)
-    return nothing
-end
+using .ReverseDiffCompat

--- a/src/compat/reversediff.jl
+++ b/src/compat/reversediff.jl
@@ -1,173 +1,154 @@
 module ReverseDiffCompat
 
-using ..ReverseDiff: ReverseDiff, value, deriv, track, SpecialInstruction
+using ..ReverseDiff: @grad, value, track, TrackedReal, TrackedVector, TrackedMatrix
 using Requires, LinearAlgebra
-const RTR = ReverseDiff.TrackedReal
-const RTV = ReverseDiff.TrackedVector
-const RTM = ReverseDiff.TrackedMatrix
-const RTA = ReverseDiff.TrackedArray
 
-import Base: vcat, hcat
 using ..Bijectors: Log, SimplexBijector, maphcat, simplex_link_jacobian, 
     simplex_invlink_jacobian, simplex_logabsdetjac_gradient
 import ..Bijectors: _eps, logabsdetjac, _logabsdetjac_scale, _simplex_bijector, 
     _simplex_inv_bijector, replace_diag
+using Distributions: LocationScale
 
-_eps(::Type{<:RTR{T}}) where {T} = _eps(T)
-
-expr = Expr(:block)
-combs = [
-    [],
-    [:AbstractArray],
-    [:RTA],
-    [:RTR],
-    [:Number],
-    [:AbstractArray, :RTA],
-    [:AbstractArray, :RTR],
-    [:AbstractArray, :Number],
-    [:RTA, :RTR],
-    [:RTA, :Number],
-]
-for c in combs, f = [:hcat, :vcat]
-    cnames = map(_ -> gensym(), c)
-    push!(expr.args, :(Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{RTA, RTR}, xs::Union{AbstractArray, Number}...) = track($f, $(cnames...), x, xs...)))
+_eps(::Type{<:TrackedReal{T}}) where {T} = _eps(T)
+function Base.minimum(d::LocationScale{<:TrackedReal})
+    m = minimum(d.ρ)
+    if isfinite(m)
+        return d.μ + d.σ * m
+    else
+        return m
+    end
 end
-@init @require DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c" @eval begin
-    $expr
-    DistributionsAD.ReverseDiffX.@grad function vcat(x::Real)
-        vcat(value(x)), (Δ) -> (Δ[1],)
+function Base.maximum(d::LocationScale{<:TrackedReal})
+    m = maximum(d.ρ)
+    if isfinite(m)
+        return d.μ + d.σ * m
+    else
+        return m
     end
-    DistributionsAD.ReverseDiffX.@grad function vcat(x1::Real, x2::Real)
-        vcat(value(x1), value(x2)), (Δ) -> (Δ[1], Δ[2])
-    end
-    DistributionsAD.ReverseDiffX.@grad function vcat(x1::AbstractVector, x2::Real)
-        vcat(value(x1), value(x2)), (Δ) -> (Δ[1:length(x1)], Δ[length(x1)+1])
-    end
+end
 
-    logabsdetjac(b::Log{1}, x::Union{RTV, RTM}) = track(logabsdetjac, b, x)
-    DistributionsAD.ReverseDiffX.@grad function logabsdetjac(b::Log{1}, x::AbstractVector)
-        return -sum(log, value(x)), Δ -> (nothing, -Δ ./ value(x))
-    end
-    DistributionsAD.ReverseDiffX.@grad function logabsdetjac(b::Log{1}, x::AbstractMatrix)
-        return -vec(sum(log, value(x); dims = 1)), Δ -> (nothing, .- Δ' ./ value(x))
-    end
+logabsdetjac(b::Log{1}, x::Union{TrackedVector, TrackedMatrix}) = track(logabsdetjac, b, x)
+@grad function logabsdetjac(b::Log{1}, x::AbstractVector)
+    return -sum(log, value(x)), Δ -> (nothing, -Δ ./ value(x))
+end
+@grad function logabsdetjac(b::Log{1}, x::AbstractMatrix)
+    return -vec(sum(log, value(x); dims = 1)), Δ -> (nothing, .- Δ' ./ value(x))
+end
 
-    function _logabsdetjac_scale(a::RTR, x::Real, ::Val{0})
-        return track(_logabsdetjac_scale, a, value(x), Val(0))
-    end
-    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::Real, x::Real, v::Val{0})
-        return _logabsdetjac_scale(value(a), value(x), Val(0)), Δ -> (inv(value(a)) .* Δ, nothing, nothing)
-    end
-    # Need to treat `AbstractVector` and `AbstractMatrix` separately due to ambiguity errors
-    function _logabsdetjac_scale(a::RTR, x::AbstractVector, ::Val{0})
-        return track(_logabsdetjac_scale, a, value(x), Val(0))
-    end
-    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::Real, x::AbstractVector, v::Val{0})
-        da = value(a)
-        J = fill(inv.(da), length(x))
-        return _logabsdetjac_scale(da, value(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
-    end
-    function _logabsdetjac_scale(a::RTR, x::AbstractMatrix, ::Val{0})
-        return track(_logabsdetjac_scale, a, value(x), Val(0))
-    end
-    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::Real, x::AbstractMatrix, v::Val{0})
-        da = value(a)
-        J = fill(size(x, 1) / da, size(x, 2))
-        return _logabsdetjac_scale(da, value(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
-    end
-    # adjoints for 1-dim and 2-dim `Scale` using `AbstractVector`
-    function _logabsdetjac_scale(a::RTV, x::AbstractVector, ::Val{1})
-        return track(_logabsdetjac_scale, a, value(x), Val(1))
-    end
-    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::RTV, x::AbstractVector, v::Val{1})
-        # ∂ᵢ (∑ⱼ log|aⱼ|) = ∑ⱼ δᵢⱼ ∂ᵢ log|aⱼ|
-        #                 = ∂ᵢ log |aᵢ|
-        #                 = (1 / aᵢ) ∂ᵢ aᵢ
-        #                 = (1 / aᵢ)
-        da = value(a)
-        J = inv.(da)
-        return _logabsdetjac_scale(da, value(x), Val(1)), Δ -> (J .* Δ, nothing, nothing)
-    end
-    function _logabsdetjac_scale(a::RTV, x::AbstractMatrix, ::Val{1})
-        return track(_logabsdetjac_scale, a, value(x), Val(1))
-    end
-    DistributionsAD.ReverseDiffX.@grad function _logabsdetjac_scale(a::RTV, x::AbstractMatrix, v::Val{1})
-        da = value(a)
-        Jᵀ = repeat(inv.(da), 1, size(x, 2))
-        return _logabsdetjac_scale(da, value(x), Val(1)), Δ -> (Jᵀ * Δ, nothing, nothing)
-    end
+function _logabsdetjac_scale(a::TrackedReal, x::Real, ::Val{0})
+    return track(_logabsdetjac_scale, a, value(x), Val(0))
+end
+@grad function _logabsdetjac_scale(a::Real, x::Real, v::Val{0})
+    return _logabsdetjac_scale(value(a), value(x), Val(0)), Δ -> (inv(value(a)) .* Δ, nothing, nothing)
+end
+# Need to treat `AbstractVector` and `AbstractMatrix` separately due to ambiguity errors
+function _logabsdetjac_scale(a::TrackedReal, x::AbstractVector, ::Val{0})
+    return track(_logabsdetjac_scale, a, value(x), Val(0))
+end
+@grad function _logabsdetjac_scale(a::Real, x::AbstractVector, v::Val{0})
+    da = value(a)
+    J = fill(inv.(da), length(x))
+    return _logabsdetjac_scale(da, value(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
+end
+function _logabsdetjac_scale(a::TrackedReal, x::AbstractMatrix, ::Val{0})
+    return track(_logabsdetjac_scale, a, value(x), Val(0))
+end
+@grad function _logabsdetjac_scale(a::Real, x::AbstractMatrix, v::Val{0})
+    da = value(a)
+    J = fill(size(x, 1) / da, size(x, 2))
+    return _logabsdetjac_scale(da, value(x), Val(0)), Δ -> (transpose(J) * Δ, nothing, nothing)
+end
+# adjoints for 1-dim and 2-dim `Scale` using `AbstractVector`
+function _logabsdetjac_scale(a::TrackedVector, x::AbstractVector, ::Val{1})
+    return track(_logabsdetjac_scale, a, value(x), Val(1))
+end
+@grad function _logabsdetjac_scale(a::TrackedVector, x::AbstractVector, v::Val{1})
+    # ∂ᵢ (∑ⱼ log|aⱼ|) = ∑ⱼ δᵢⱼ ∂ᵢ log|aⱼ|
+    #                 = ∂ᵢ log |aᵢ|
+    #                 = (1 / aᵢ) ∂ᵢ aᵢ
+    #                 = (1 / aᵢ)
+    da = value(a)
+    J = inv.(da)
+    return _logabsdetjac_scale(da, value(x), Val(1)), Δ -> (J .* Δ, nothing, nothing)
+end
+function _logabsdetjac_scale(a::TrackedVector, x::AbstractMatrix, ::Val{1})
+    return track(_logabsdetjac_scale, a, value(x), Val(1))
+end
+@grad function _logabsdetjac_scale(a::TrackedVector, x::AbstractMatrix, v::Val{1})
+    da = value(a)
+    Jᵀ = repeat(inv.(da), 1, size(x, 2))
+    return _logabsdetjac_scale(da, value(x), Val(1)), Δ -> (Jᵀ * Δ, nothing, nothing)
+end
 
-    function _simplex_bijector(X::Union{RTV, RTM}, b::SimplexBijector)
-        return track(_simplex_bijector, X, b)
+function _simplex_bijector(X::Union{TrackedVector, TrackedMatrix}, b::SimplexBijector)
+    return track(_simplex_bijector, X, b)
+end
+@grad function _simplex_bijector(Y::AbstractVector, b::SimplexBijector)
+    Yd = value(Y)
+    return _simplex_bijector(Yd, b), Δ -> (simplex_link_jacobian(Yd)' * Δ, nothing)
+end
+@grad function _simplex_bijector(Y::AbstractMatrix, b::SimplexBijector)
+    Yd = value(Y)
+    return _simplex_bijector(Yd, b), Δ -> begin
+        maphcat(eachcol(Yd), eachcol(Δ)) do c1, c2
+            simplex_link_jacobian(c1)' * c2
+        end, nothing
     end
-    DistributionsAD.ReverseDiffX.@grad function _simplex_bijector(Y::AbstractVector, b::SimplexBijector)
-        Yd = value(Y)
-        return _simplex_bijector(Yd, b), Δ -> (simplex_link_jacobian(Yd)' * Δ, nothing)
-    end
-    DistributionsAD.ReverseDiffX.@grad function _simplex_bijector(Y::AbstractMatrix, b::SimplexBijector)
-        Yd = value(Y)
-        return _simplex_bijector(Yd, b), Δ -> begin
-            maphcat(eachcol(Yd), eachcol(Δ)) do c1, c2
-                simplex_link_jacobian(c1)' * c2
-            end, nothing
-        end
-    end
+end
 
-    function _simplex_inv_bijector(X::Union{RTV, RTM}, b::SimplexBijector)
-        return track(_simplex_inv_bijector, X, b)
+function _simplex_inv_bijector(X::Union{TrackedVector, TrackedMatrix}, b::SimplexBijector)
+    return track(_simplex_inv_bijector, X, b)
+end
+@grad function _simplex_inv_bijector(Y::AbstractVector, b::SimplexBijector)
+    Yd = value(Y)
+    return _simplex_inv_bijector(Yd, b), Δ -> (simplex_invlink_jacobian(Yd)' * Δ, nothing)
+end
+@grad function _simplex_inv_bijector(Y::AbstractMatrix, b::SimplexBijector)
+    Yd = value(Y)
+    return _simplex_inv_bijector(Yd, b), Δ -> begin
+        maphcat(eachcol(Yd), eachcol(Δ)) do c1, c2
+            simplex_invlink_jacobian(c1)' * c2
+        end, nothing
     end
-    DistributionsAD.ReverseDiffX.@grad function _simplex_inv_bijector(Y::AbstractVector, b::SimplexBijector)
-        Yd = value(Y)
-        return _simplex_inv_bijector(Yd, b), Δ -> (simplex_invlink_jacobian(Yd)' * Δ, nothing)
-    end
-    DistributionsAD.ReverseDiffX.@grad function _simplex_inv_bijector(Y::AbstractMatrix, b::SimplexBijector)
-        Yd = value(Y)
-        return _simplex_inv_bijector(Yd, b), Δ -> begin
-            maphcat(eachcol(Yd), eachcol(Δ)) do c1, c2
-                simplex_invlink_jacobian(c1)' * c2
-            end, nothing
-        end
-    end
+end
 
-    replace_diag(::typeof(log), X::RTM) = track(replace_diag, log, X)
-    DistributionsAD.ReverseDiffX.@grad function replace_diag(::typeof(log), X)
-        Xd = value(X)
-        f(i, j) = i == j ? log(Xd[i, j]) : Xd[i, j]
-        out = f.(1:size(Xd, 1), (1:size(Xd, 2))')
-        out, ∇ -> begin
-            g(i, j) = i == j ? ∇[i, j]/Xd[i, j] : ∇[i, j]
-            return (nothing, g.(1:size(Xd, 1), (1:size(Xd, 2))'))
-        end
+replace_diag(::typeof(log), X::TrackedMatrix) = track(replace_diag, log, X)
+@grad function replace_diag(::typeof(log), X)
+    Xd = value(X)
+    f(i, j) = i == j ? log(Xd[i, j]) : Xd[i, j]
+    out = f.(1:size(Xd, 1), (1:size(Xd, 2))')
+    out, ∇ -> begin
+        g(i, j) = i == j ? ∇[i, j]/Xd[i, j] : ∇[i, j]
+        return (nothing, g.(1:size(Xd, 1), (1:size(Xd, 2))'))
     end
+end
 
-    replace_diag(::typeof(exp), X::RTM) = track(replace_diag, exp, X)
-    DistributionsAD.ReverseDiffX.@grad function replace_diag(::typeof(exp), X)
-        Xd = value(X)
-        f(i, j) = ifelse(i == j, exp(Xd[i, j]), Xd[i, j])
-        out = f.(1:size(Xd, 1), (1:size(Xd, 2))')
-        out, ∇ -> begin
-            g(i, j) = ifelse(i == j, ∇[i, j]*exp(Xd[i, j]), ∇[i, j])
-            return (nothing, g.(1:size(Xd, 1), (1:size(Xd, 2))'))
-        end
+replace_diag(::typeof(exp), X::TrackedMatrix) = track(replace_diag, exp, X)
+@grad function replace_diag(::typeof(exp), X)
+    Xd = value(X)
+    f(i, j) = ifelse(i == j, exp(Xd[i, j]), Xd[i, j])
+    out = f.(1:size(Xd, 1), (1:size(Xd, 2))')
+    out, ∇ -> begin
+        g(i, j) = ifelse(i == j, ∇[i, j]*exp(Xd[i, j]), ∇[i, j])
+        return (nothing, g.(1:size(Xd, 1), (1:size(Xd, 2))'))
     end
+end
 
-    logabsdetjac(b::SimplexBijector, x::Union{RTV, RTM}) = track(logabsdetjac, b, x)
-    DistributionsAD.ReverseDiffX.@grad function logabsdetjac(b::SimplexBijector, x::AbstractVector)
-        xd = value(x)
-        return logabsdetjac(b, xd), Δ -> begin
-            (nothing, simplex_logabsdetjac_gradient(xd) * Δ)
-        end
+logabsdetjac(b::SimplexBijector, x::Union{TrackedVector, TrackedMatrix}) = track(logabsdetjac, b, x)
+@grad function logabsdetjac(b::SimplexBijector, x::AbstractVector)
+    xd = value(x)
+    return logabsdetjac(b, xd), Δ -> begin
+        (nothing, simplex_logabsdetjac_gradient(xd) * Δ)
     end
-    DistributionsAD.ReverseDiffX.@grad function logabsdetjac(b::SimplexBijector, x::AbstractMatrix)
-        xd = value(x)
-        return logabsdetjac(b, xd), Δ -> begin
-            (nothing, maphcat(eachcol(xd), Δ) do c, g
-                simplex_logabsdetjac_gradient(c) * g
-            end)
-        end
+end
+@grad function logabsdetjac(b::SimplexBijector, x::AbstractMatrix)
+    xd = value(x)
+    return logabsdetjac(b, xd), Δ -> begin
+        (nothing, maphcat(eachcol(xd), Δ) do c, g
+            simplex_logabsdetjac_gradient(c) * g
+        end)
     end
 end
 
 end
 
-using .ReverseDiffCompat

--- a/src/compat/reversediff.jl
+++ b/src/compat/reversediff.jl
@@ -32,8 +32,7 @@ for c in combs, f = [:hcat, :vcat]
     cnames = map(_ -> gensym(), c)
     push!(expr.args, :(Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{RTA, RTR}, xs::Union{AbstractArray, Number}...) = track($f, $(cnames...), x, xs...)))
 end
-using DistributionsAD
-#=@init @require DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c"=# @eval begin
+@init @require DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c" @eval begin
     $expr
     DistributionsAD.ReverseDiffX.@grad function vcat(x::Real)
         vcat(value(x)), (Δ) -> (Δ[1],)

--- a/src/compat/tracker.jl
+++ b/src/compat/tracker.jl
@@ -11,10 +11,6 @@ using .Tracker: Tracker,
                 param
 using LinearAlgebra
 
-# Different from Tracker.istracked
-_istracked(x::AbstractArray{<:TrackedReal}) = true
-_istracked(::TrackedArray) = false
-
 _eps(::Type{<:TrackedReal{T}}) where {T} = _eps(T)
 function Base.minimum(d::LocationScale{<:TrackedReal})
     m = minimum(d.ρ)

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -1,0 +1,76 @@
+macro register(dist)
+    return quote
+        Bijectors.eval(getexpr($(esc(dist))))
+        toflatten(::$(esc(dist))) = true
+    end
+end
+function getexpr(Tdist)
+    x = gensym(:x)
+    fnames = fieldnames(Tdist)
+    flattened_args = Expr(:tuple, [:(dist.$f) for f in fnames]...)
+    func = Expr(:->, 
+                Expr(:tuple, fnames..., x), 
+                Expr(:block,
+                    Expr(:call, :logpdf_with_trans,
+                        Expr(:call, :($Tdist), fnames...),
+                        x,
+                        :trans,
+                    )
+                )
+            )
+    return :(flatten(dist::$Tdist, trans) = ($func, $flattened_args))
+end
+const flattened_dists = [   Bernoulli,
+                            BetaBinomial,
+                            Binomial,
+                            Geometric,
+                            NegativeBinomial,
+                            Poisson,
+                            Skellam,
+                            Arcsine,
+                            Beta,
+                            BetaPrime,
+                            Biweight,
+                            Cauchy,
+                            Chernoff,
+                            Chi,
+                            Chisq,
+                            Cosine,
+                            Epanechnikov,
+                            Erlang,
+                            Exponential,
+                            FDist,
+                            Frechet,
+                            Gamma,
+                            GeneralizedExtremeValue,
+                            GeneralizedPareto,
+                            Gumbel,
+                            #InverseGamma,
+                            InverseGaussian,
+                            Kolmogorov,
+                            Laplace,
+                            Levy,
+                            LocationScale,
+                            Logistic,
+                            LogitNormal,
+                            LogNormal,
+                            Normal,
+                            #NormalCanon,
+                            #NormalInverseGaussian,
+                            Pareto,
+                            PGeneralizedGaussian,
+                            Rayleigh,
+                            SymTriangularDist,
+                            TDist,
+                            TriangularDist,
+                            Triweight,
+                            #Truncated,
+                            #VonMises,
+                        ]
+for T in flattened_dists
+    @eval toflatten(::$T) = true
+end
+toflatten(::Distribution) = false
+for T in flattened_dists
+    eval(getexpr(T))
+end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -163,11 +163,11 @@ end
             y = @inferred b(x)
 
             ys = @inferred b(xs)
-            @test @inferred(b(param(xs))) isa TrackedArray
+            @inferred(b(param(xs)))
 
             x_ = @inferred ib(y)
             xs_ = @inferred ib(ys)
-            @test @inferred(ib(param(ys))) isa TrackedArray
+            @inferred(ib(param(ys)))
 
             result = @inferred forward(b, x)
             results = @inferred forward(b, xs)
@@ -505,8 +505,8 @@ end
     b1 = DistributionBijector(d)
     b2 = DistributionBijector(Gamma())
 
-    cb = b1 ∘ b2
-    @test cb(x) ≈ b1(b2(x))
+    cb = inv(b1) ∘ b2
+    @test cb(x) ≈ inv(b1)(b2(x))
 
     # contrived example
     b = bijector(d)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Tracker, ForwardDiff, Zygote, DistributionsAD, Bijectors, ReverseDiff
+using ReverseDiff, Tracker, ForwardDiff, Zygote, DistributionsAD, Bijectors
 using Random, LinearAlgebra, Combinatorics, Test
 using DistributionsAD: TuringUniform, TuringMvNormal, TuringMvLogNormal, 
                         TuringPoissonBinomial


### PR DESCRIPTION
This PR does something similar to https://github.com/TuringLang/DistributionsAD.jl/pull/63 by not concatenating arrays of `TrackedReal`s to `TrackedArrays` all over the place. This PR also does the same flattening trick in DistributionsAD for `filldist` to enable efficient broadcasting in the `logpdf` of `filldist` returning `TrackedArray`s.

This PR also fixes the `invlink` issue in `arraydist` where `invlink` was the identity for `arraydist` of univariate distributions. In this PR, I also define a number of ReverseDiff custom adjoints using the `@grad` macro in https://github.com/JuliaDiff/ReverseDiff.jl/pull/123. Some type piracy code for AD was also removed from here and added to DistributionsAD in https://github.com/TuringLang/DistributionsAD.jl/pull/63. So this PR requires both the ReverseDiff and DistributionsAD PRs to be merged and released.