### PR TITLE
Fixed bug in logabsdetjac for Composed using Arrays

### DIFF
--- a/src/bijectors/composed.jl
+++ b/src/bijectors/composed.jl
@@ -183,7 +183,7 @@ function logabsdetjac(cb::Composed, x)
         logjac += res.logabsdetjac
     end
 
-    return (rv = y, logabsdetjac = logjac)
+    return logjac
 end
 
 @generated function logabsdetjac(cb::Composed{T}, x) where {T<:Tuple}

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -275,6 +275,9 @@ end
         @test cb2 isa Composed{<:Tuple}
         cb3 = cb1 ∘ cb2
         @test cb3 isa Composed{<:Tuple}
+        
+        @test logabsdetjac(cb1, 1.) isa Real
+        @test logabsdetjac(cb1, 1.) == 1.
 
         @test inv(cb1) isa Composed{<:Tuple}
         @test inv(cb2) isa Composed{<:Tuple}
@@ -287,6 +290,9 @@ end
         @test cb2 isa Composed{<:AbstractArray}
         cb3 = cb1 ∘ cb2
         @test cb3 isa Composed{<:AbstractArray}
+        
+        @test logabsdetjac(cb1, 1.) isa Real
+        @test logabsdetjac(cb1, 1.) == 1.
 
         @test inv(cb1) isa Composed{<:AbstractArray}
         @test inv(cb2) isa Composed{<:AbstractArray}


### PR DESCRIPTION
There's a bug in `logabsdetjac` for `Composed{<:AbstractArray}` where it returns `(rv = ..., logabsdetjac = ...)`, i.e. same as `forward`. This PR fixes that.