### PR TITLE
Implement `bijector` for `AbstractMvNormal`

### DIFF
--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -50,8 +50,7 @@ end
 end
 
 bijector(d::Normal) = Identity{0}()
-bijector(d::MvNormal) = Identity{1}()
-bijector(d::MvNormalCanon) = Identity{1}()
+bijector(d::Distributions.AbstractMvNormal) = Identity{1}()
 bijector(d::Distributions.AbstractMvLogNormal) = Log{1}()
 bijector(d::PositiveDistribution) = Log{0}()
 bijector(d::SimplexDistribution) = SimplexBijector{1}()


### PR DESCRIPTION
Implements `bijector` for `AbstractMvNormal` instead of each of the `MvNormal` types on per-basis.

Ref: https://github.com/willtebbutt/Stheno.jl/issues/113