### PR TITLE
Fix bug in Stacked

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/bijectors/stacked.jl
+++ b/src/bijectors/stacked.jl
@@ -115,7 +115,7 @@ function logabsdetjac(
     init = sum(logabsdetjac(b.bs[1], x[b.ranges[1]]))
 
     return if N == 1
-        return init
+        init
     else
         init + sum(2:N) do i
             sum(logabsdetjac(b.bs[i], x[b.ranges[i]]))

--- a/src/bijectors/stacked.jl
+++ b/src/bijectors/stacked.jl
@@ -113,14 +113,14 @@ function logabsdetjac(
     x::AbstractVector{<:Real}
 ) where {N}
     init = sum(logabsdetjac(b.bs[1], x[b.ranges[1]]))
-    init + sum(2:N) do i
-        sum(logabsdetjac(b.bs[i], x[b.ranges[i]]))
-    end
-end
 
-# Handle the case of just one bijector
-function logabsdetjac(b::Stacked{<:Tuple{<:Bijector}, <:Tuple{<:Bijector}}, x::AbstractVector{<:Real})
-    return sum(logabsdetjac(b.bs[1], x[b.ranges[1]]))
+    return if N == 1
+        return init
+    else
+        init + sum(2:N) do i
+            sum(logabsdetjac(b.bs[i], x[b.ranges[i]]))
+        end
+    end
 end
 
 function logabsdetjac(b::Stacked, x::AbstractMatrix{<:Real})

--- a/src/bijectors/stacked.jl
+++ b/src/bijectors/stacked.jl
@@ -109,7 +109,7 @@ function logabsdetjac(
 end
 
 function logabsdetjac(
-    b::Stacked{<:Tuple{Vararg{<:Any, N}}},
+    b::Stacked{<:Tuple{Vararg{<:Any, N}}, <:Tuple{Vararg{<:Any, N}}},
     x::AbstractVector{<:Real}
 ) where {N}
     init = sum(logabsdetjac(b.bs[1], x[b.ranges[1]]))
@@ -119,7 +119,7 @@ function logabsdetjac(
 end
 
 # Handle the case of just one bijector
-function logabsdetjac(b::Stacked{<:Tuple{<:Bijector}}, x::AbstractVector{<:Real})
+function logabsdetjac(b::Stacked{<:Tuple{<:Bijector}, <:Tuple{<:Bijector}}, x::AbstractVector{<:Real})
     return sum(logabsdetjac(b.bs[1], x[b.ranges[1]]))
 end
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -637,7 +637,8 @@ end
     @test_throws AssertionError sb(x)
 
     # Mixed versions
-    sb = Stacked([Bijectors.Exp(), Bijectors.SimplexBijector()], (1:1, 2:3])
+    # Tuple, Array
+    sb = Stacked([Bijectors.Exp(), Bijectors.SimplexBijector()], (1:1, 2:3))
     x = ones(3) ./ 3.0
     res = forward(sb, x)
     @test sb(param(x)) isa TrackedArray
@@ -649,6 +650,7 @@ end
     x = ones(4) ./ 4.0
     @test_throws AssertionError sb(x)
 
+    # Array, Tuple
     sb = Stacked((Bijectors.Exp(), Bijectors.SimplexBijector()), [1:1, 2:3])
     x = ones(3) ./ 3.0
     res = forward(sb, x)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -636,6 +636,32 @@ end
     x = ones(4) ./ 4.0
     @test_throws AssertionError sb(x)
 
+    # Mixed versions
+    sb = Stacked([Bijectors.Exp(), Bijectors.SimplexBijector()], (1:1, 2:3])
+    x = ones(3) ./ 3.0
+    res = forward(sb, x)
+    @test sb(param(x)) isa TrackedArray
+    @test sb(x) == [exp(x[1]), sb.bs[2](x[2:3])...]
+    @test res.rv == [exp(x[1]), sb.bs[2](x[2:3])...]
+    @test logabsdetjac(sb, x) == sum([sum(logabsdetjac(sb.bs[i], x[sb.ranges[i]])) for i = 1:2])
+    @test res.logabsdetjac == logabsdetjac(sb, x)
+
+    x = ones(4) ./ 4.0
+    @test_throws AssertionError sb(x)
+
+    sb = Stacked((Bijectors.Exp(), Bijectors.SimplexBijector()), [1:1, 2:3])
+    x = ones(3) ./ 3.0
+    res = forward(sb, x)
+    @test sb(param(x)) isa TrackedArray
+    @test sb(x) == [exp(x[1]), sb.bs[2](x[2:3])...]
+    @test res.rv == [exp(x[1]), sb.bs[2](x[2:3])...]
+    @test logabsdetjac(sb, x) == sum([sum(logabsdetjac(sb.bs[i], x[sb.ranges[i]])) for i = 1:2])
+    @test res.logabsdetjac == logabsdetjac(sb, x)
+
+    x = ones(4) ./ 4.0
+    @test_throws AssertionError sb(x)
+
+
     @testset "Stacked: ADVI with MvNormal" begin
         # MvNormal test
         dists = [
@@ -798,8 +824,8 @@ end
         SimplexBijector(),
         Stacked((Exp{0}(), Log{0}())),
         Stacked((Log{0}(), Exp{0}())),
-        # Stacked([Exp{0}(), Log{0}()]),
-        # Stacked([Log{0}(), Exp{0}()]),
+        Stacked([Exp{0}(), Log{0}()]),
+        Stacked([Log{0}(), Exp{0}()]),
         Composed((Exp{0}(), Log{0}())),
         Composed((Log{0}(), Exp{0}())),
         # Composed([Exp{0}(), Log{0}()]),


### PR DESCRIPTION
Before #177 we had very opinionated constructors that would ensure that if you were constructing a `Stacked` with a `Tuple` as the container for the bijectors, you'd also get a `Tuple` container for the ranges. After relaxing the requirements/assumptions made, it's now possible (but of course not encournaged) to have a combination of `Array` and `Tuple`, e.g. `Stacked((Exp(), ), [1:1, ])`. This will then dispatch to the impl that unrolls the map even though it shouldn't because we only specifiy the type of the first parameter in the current impl.

This PR fixes this bug by making it so we only dispatch to the `@generated` impl if both type-parameters are `Tuple`, and falls back to the non-generated impl if this is not the case.