### PR TITLE
Fixed double double subscripts in Docs

### DIFF
--- a/src/bijectors/radial_layer.jl
+++ b/src/bijectors/radial_layer.jl
@@ -105,15 +105,15 @@ end
 
 Compute the unique solution ``r`` to the equation
 ```math
-\\|y_minus_z0\\|_2 = r \\left(1 + \\frac{α_plus_β_hat - α}{α + r}\\right)
+\\|y_minus_z0\\|_2 = r \\left(1 + \\frac{α_{plus_{β}_{hat}} - α}{α + r}\\right)
 ```
 subject to ``r ≥ 0`` and ``r ≠ α``.
 
-Since ``α > 0`` and ``α_plus_β_hat > 0``, the solution is unique and given by
+Since ``α > 0`` and ``α_{plus_{β}_{hat}} > 0``, the solution is unique and given by
 ```math
-r = (\\sqrt{(α_plus_β_hat - γ)^2 + 4 α γ} - (α_plus_β_hat - γ)) / 2,
+r = (\\sqrt{(α_{plus_{β}_{hat}} - γ)^2 + 4 α γ} - (α_{plus_{β}_{hat}} - γ)) / 2,
 ```
-where ``γ = \\|y_minus_z0\\|_2``. For details see appendix A.2 of the reference.
+where ``γ = \\|y_{minus_{z0}}\\|_2``. For details see appendix A.2 of the reference.
 
 # References
 


### PR DESCRIPTION
This is not rendering right in Turing.ml Documentation. See here (https://turing.ml/dev/docs/library/bijectors/#Bijectors.compute_r-Tuple{AbstractVector{var%22#s111%22}%20where%20var%22#s111%22%3C:Real,%20Any,%20Any}). I've tried to corrected it but I don't know if the intent is to signal that α is positive constrained (and `y` is negative constrained). I would do something like $\alpha^{+}$ (or $y^{-}$).

<img width="712" alt="Screen Shot 2021-06-13 at 10 27 11" src="https://user-images.githubusercontent.com/43353831/121809159-148abd80-cc32-11eb-95a2-fef54b88f1d1.png">
