### PR TITLE
Default `bijector` implementation for `TransformedDistribution`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -35,6 +35,7 @@ transformed(d) = transformed(d, bijector(d))
 
 Returns the constrained-to-unconstrained bijector for distribution `d`.
 """
+bijector(td::TransformedDistribution) = bijector(td.dist) ∘ inv(td.transform)
 bijector(d::DiscreteUnivariateDistribution) = Identity{0}()
 bijector(d::DiscreteMultivariateDistribution) = Identity{1}()
 bijector(d::ContinuousUnivariateDistribution) = TruncatedBijector(minimum(d), maximum(d))

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -108,8 +108,10 @@ end
             b = bijector(d)
             x = rand(d)
             y = b(x)
-            @test log(abs(ForwardDiff.derivative(b, x))) ≈ logabsdetjac(b, x)
-            @test log(abs(ForwardDiff.derivative(inv(b), y))) ≈ logabsdetjac(inv(b), y)
+            # `ForwardDiff.derivative` can lead to some numerical inaccuracy,
+            # so we use a slightly higher `atol` than default.
+            @test log(abs(ForwardDiff.derivative(b, x))) ≈ logabsdetjac(b, x) atol=1e-6
+            @test log(abs(ForwardDiff.derivative(inv(b), y))) ≈ logabsdetjac(inv(b), y) atol=1e-6
         end
 
         @testset "$dist: ForwardDiff AD" begin

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -403,6 +403,8 @@ end
         MvLogNormal(MvNormal(randn(10), exp.(randn(10)))),
         Dirichlet([1000 * one(Float64), eps(Float64)]), 
         Dirichlet([eps(Float64), 1000 * one(Float64)]),
+        transformed(MvNormal(randn(10), exp.(randn(10)))),
+        transformed(MvLogNormal(MvNormal(randn(10), exp.(randn(10)))))
     ]
 
     for dist in vector_dists

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -452,9 +452,11 @@ end
                 b = bijector(dist)
                 x = rand(dist)
                 y = b(x)
+                # `ForwardDiff.derivative` can lead to some numerical inaccuracy,
+                # so we use a slightly higher `atol` than default.
                 @test b(param(x)) isa TrackedArray
-                @test log(abs(det(ForwardDiff.jacobian(b, x)))) ≈ logabsdetjac(b, x)
-                @test log(abs(det(ForwardDiff.jacobian(inv(b), y)))) ≈ logabsdetjac(inv(b), y)
+                @test log(abs(det(ForwardDiff.jacobian(b, x)))) ≈ logabsdetjac(b, x) atol=1e-6
+                @test log(abs(det(ForwardDiff.jacobian(inv(b), y)))) ≈ logabsdetjac(inv(b), y) atol=1e-6
             end
         end
     end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -63,6 +63,8 @@ end
         Rayleigh(1.0),
         TDist(2),
         truncated(Normal(0, 1), -Inf, 2),
+        transformed(Beta(2,2)),
+        transformed(Exponential()),
     ]
     
     for dist in uni_dists


### PR DESCRIPTION
Currently we're missing an implementation for `bijector(td::TransformedDistribution)` which in turn means that you can't, without a bit of work, use transformed distributions in, say, a DPPL-model.

This is stupid because it's trivial to construct this bijector: just invert `td.transform`, bringing us back the original domain of `td.dist`, and then compose this with the bijector for `td.dist`, which then takes us to real space.

EDIT: Btw, I have the right to call it stupid because I'm the one who didn't do it.