### PR TITLE
Use more conservative initial bracket

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.9.10"
+version = "0.9.11"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/bijectors/planar_layer.jl
+++ b/src/bijectors/planar_layer.jl
@@ -143,6 +143,9 @@ Thus
 α̂ - |wt_u_hat| - wt_y \\leq 0 \\leq α̂ + |wt_u_hat| - wt_y,
 ```
 which implies ``α̂ ∈ [wt_y - |wt_u_hat|, wt_y + |wt_u_hat|]``.
+To avoid floating point issues if ``α̂  = wt_y ± |wt_u_hat|``, we use the more conservative
+interval ``[wt_y - 2 |wt_u_hat|, wt_y + 2|wt_u_hat|]`` as initial bracket, at the cost of
+one additional iteration step.
 
 # References
 
@@ -155,9 +158,9 @@ function find_alpha(wt_y::Real, wt_u_hat::Real, b::Real)
 end
 function find_alpha(wt_y::T, wt_u_hat::T, b::T) where {T<:Real}
     # Compute the initial bracket (see above).
-    abs_wt_u_hat = abs(wt_u_hat)
-    lower = float(wt_y - abs_wt_u_hat)
-    upper = float(wt_y + abs_wt_u_hat)
+    Δ = 2 * abs(wt_u_hat)
+    lower = float(wt_y - Δ)
+    upper = float(wt_y + Δ)
 
     # Handle empty brackets (https://github.com/TuringLang/Bijectors.jl/issues/204)
     if lower == upper

--- a/test/norm_flows.jl
+++ b/test/norm_flows.jl
@@ -59,6 +59,13 @@ end
                 end
             end
         end
+
+        # floating point issues
+        # https://github.com/TuringLang/Bijectors.jl/issues/204
+        wt_y = 0.8845640339582252
+        wt_u_hat = 0.8296950433716855
+        b = -1e8
+        @test Bijectors.find_alpha(wt_y, wt_u_hat, b) ≈ wt_y + wt_u_hat
     end
 end
 


### PR DESCRIPTION
Fixes the numerical issues reported in https://github.com/TuringLang/Bijectors.jl/issues/204#issuecomment-947145099. I checked that the new test errors with the master branch.

cc: @Red-Portal