### PR TITLE
Throw error if `ordered` unsafe to use

### DIFF
--- a/src/bijectors/ordered.jl
+++ b/src/bijectors/ordered.jl
@@ -13,6 +13,8 @@ struct OrderedBijector <: Bijector{1} end
     ordered(d::Distribution)
 
 Return a `Distribution` whose support are ordered vectors, i.e., vectors with increasingly ordered elements.
+
+This transformation is currently only supported for otherwise unconstrained distributions.
 """
 function ordered(d::ContinuousMultivariateDistribution)
     if !isa(bijector(d), Identity)

--- a/src/bijectors/ordered.jl
+++ b/src/bijectors/ordered.jl
@@ -14,7 +14,12 @@ struct OrderedBijector <: Bijector{1} end
 
 Return a `Distribution` whose support are ordered vectors, i.e., vectors with increasingly ordered elements.
 """
-ordered(d::ContinuousMultivariateDistribution) = Bijectors.transformed(d, OrderedBijector())
+function ordered(d::ContinuousMultivariateDistribution)
+    if !isa(bijector(d), Identity)
+        throw(ArgumentError("ordered transform is currently only supported for unconstrained distributions."))
+    end
+    return Bijectors.transformed(d, OrderedBijector())
+end
 
 (b::OrderedBijector)(y::AbstractVecOrMat) = _transform_ordered(y)
 

--- a/test/bijectors/ordered.jl
+++ b/test/bijectors/ordered.jl
@@ -1,4 +1,5 @@
-import Bijectors: OrderedBijector
+import Bijectors: OrderedBijector, ordered
+using LinearAlgebra
 
 @testset "OrderedBijector" begin
     b = OrderedBijector()
@@ -19,4 +20,23 @@ import Bijectors: OrderedBijector
     ys = b(xs)
     @test sort(ys[:, 1]) == ys[:, 1]
     @test sort(ys[:, 2]) == ys[:, 2]
+end
+
+@testset "ordered" begin
+    d = MvNormal(1:5, Diagonal(6:10))
+    d_ordered = ordered(d)
+    @test d_ordered isa Bijectors.TransformedDistribution
+    @test d_ordered.dist === d
+    @test d_ordered.transform isa OrderedBijector
+    y = randn(5)
+    x = inv(bijector(d_ordered))(y)
+    @test issorted(x)
+
+    d = Product(fill(Normal(), 5))
+    # currently errors because `bijector(Product(fill(Normal(), 5)))` is not an `Identity`
+    @test_broken ordered(d) isa Bijectors.TransformedDistribution
+
+    # non-Identity bijector is not supported
+    d = Dirichlet(ones(5))
+    @test_throws ArgumentError ordered(d)
 end


### PR DESCRIPTION
As noted in https://github.com/TuringLang/Bijectors.jl/issues/220#issuecomment-1409115410, `ordered(d)` does the incorrect thing unless `d` is unconstrained. This PR adds a check that throws an error if this is not the case. Note that examples like this will now error even though they are fine to use with `ordered`, since they don't return a `Identity` bijector:

```julia
julia> bijector(Product(fill(Normal(), 5)))
Bijectors.TruncatedBijector{1, Float64, Float64}(-Inf, Inf)

julia> bijector(Product([Normal(), Cauchy()]))
Bijectors.TruncatedBijector{1, Vector{Float64}, Vector{Float64}}([-Inf, -Inf], [Inf, Inf])
```