### PR TITLE
Missing impl of `with_logabsdet_jacobian` for `PDBijector`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -37,7 +37,7 @@ using LinearAlgebra: AbstractTriangular
 
 using InverseFunctions: InverseFunctions
 
-import ChangesOfVariables: with_logabsdet_jacobian
+import ChangesOfVariables: ChangesOfVariables, with_logabsdet_jacobian
 import InverseFunctions: inverse
 
 import ChainRulesCore

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -30,11 +30,12 @@ end
 
 function logabsdetjac_pdbijector_chol(Xcf::Cholesky)
     # NOTE: Use `UpperTriangular` here because we only need `diag(U)`
-    # and `U` is by default already constructed in `Cholesky`.
-    U = Xcf.U
+    # and `UL` is by default already constructed in `Cholesky`.
+    UL = Xcf.UL
     T = eltype(U)
-    d = size(U, 1)
-    return - sum((d .- (1:d) .+ 2) .* log.(diag(U))) - d * log(T(2))
+    d = size(UL, 1)
+    z = sum((d + 1):(-1):2 .* log.(diag(UL)))
+    return - (z + d * oftype(z, logtwo))
 end
 
 # TODO: Implement explicitly.

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -34,7 +34,7 @@ function logabsdetjac_pdbijector_chol(Xcf::Cholesky)
     # and `UL` is by default already constructed in `Cholesky`.
     UL = Xcf.UL
     d = size(UL, 1)
-    z = sum((d + 1):(-1):2 .* log.(diag(UL)))
+    z = sum(((d + 1):(-1):2) .* log.(diag(UL)))
     return - (z + d * oftype(z, logtwo))
 end
 

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -35,7 +35,7 @@ function logabsdetjac_pdbijector_chol(Xcf::Cholesky)
     UL = Xcf.UL
     d = size(UL, 1)
     z = sum(((d + 1):(-1):2) .* log.(diag(UL)))
-    return - (z + d * oftype(z, logtwo))
+    return - (z + d * oftype(z, IrrationalConstants.logtwo))
 end
 
 # TODO: Implement explicitly.

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -32,7 +32,6 @@ function logabsdetjac_pdbijector_chol(Xcf::Cholesky)
     # NOTE: Use `UpperTriangular` here because we only need `diag(U)`
     # and `UL` is by default already constructed in `Cholesky`.
     UL = Xcf.UL
-    T = eltype(U)
     d = size(UL, 1)
     z = sum((d + 1):(-1):2 .* log.(diag(UL)))
     return - (z + d * oftype(z, logtwo))

--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -9,9 +9,10 @@ function replace_diag(f, X)
 end
 transform(b::PDBijector, X::AbstractMatrix{<:Real}) = pd_link(X)
 function pd_link(X)
-    Y = cholesky(X; check = true).L
+    Y = lower(parent(cholesky(X; check = true).L))
     return replace_diag(log, Y)
 end
+lower(A::AbstractMatrix) = convert(typeof(A), LowerTriangular(A))
 
 function transform(ib::Inverse{PDBijector}, Y::AbstractMatrix{<:Real})
     X = replace_diag(exp, Y)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -58,7 +58,7 @@ Transform `x` using `b`, treating `x` as a single input.
 transform(f::F, x) where {F<:Function} = f(x)
 function transform(t::Transform, x)
     res = with_logabsdet_jacobian(t, x)
-    if res === ChangesOfVariables.NoLogAbsDetJacobian()
+    if res isa ChangesOfVariables.NoLogAbsDetJacobian
         error("`transform` not implemented for $(typeof(b)); implement `transform` and/or `with_logabsdet_jacobian`.")
     end
 
@@ -82,7 +82,7 @@ Return `log(abs(det(J(b, x))))`, where `J(b, x)` is the jacobian of `b` at `x`.
 """
 function logabsdetjac(b, x)
     res = with_logabsdet_jacobian(b, x)
-    if res === ChangesOfVariables.NoLogAbsDetJacobian()
+    if res isa ChangesOfVariables.NoLogAbsDetJacobian
         error("`logabsdetjac` not implemented for $(typeof(b)); implement `logabsdetjac` and/or `with_logabsdet_jacobian`.")
     end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -56,7 +56,14 @@ Broadcast.broadcastable(b::Transform) = Ref(b)
 Transform `x` using `b`, treating `x` as a single input.
 """
 transform(f::F, x) where {F<:Function} = f(x)
-transform(t::Transform, x) = first(with_logabsdet_jacobian(t, x))
+function transform(t::Transform, x)
+    res = with_logabsdet_jacobian(t, x)
+    if res === ChangesOfVariables.NoLogAbsDetJacobian()
+        error("`transform` not implemented for $(typeof(b)); implement `transform` and/or `with_logabsdet_jacobian`.")
+    end
+
+    return first(res)
+end
 
 """
     transform!(b, x[, y])
@@ -73,7 +80,14 @@ transform!(b, x, y) = copyto!(y, transform(b, x))
 
 Return `log(abs(det(J(b, x))))`, where `J(b, x)` is the jacobian of `b` at `x`.
 """
-logabsdetjac(b, x) = last(with_logabsdet_jacobian(b, x))
+function logabsdetjac(b, x)
+    res = with_logabsdet_jacobian(b, x)
+    if res === ChangesOfVariables.NoLogAbsDetJacobian()
+        error("`logabsdetjac` not implemented for $(typeof(b)); implement `logabsdetjac` and/or `with_logabsdet_jacobian`.")
+    end
+
+    return last(res)
+end
 
 """
     logabsdetjac!(b, x[, logjac])

--- a/test/bijectors/pd.jl
+++ b/test/bijectors/pd.jl
@@ -1,0 +1,13 @@
+using Bijectors, DistributionsAD, LinearAlgebra, Test
+using Bijectors: PDBijector
+
+@testset "PDBijector" begin
+    d = 5
+    b = PDBijector()
+    dist = Wishart(d, Matrix{Float64}(I, d, d))
+    x = rand(dist)
+    # NOTE: `PDBijector` technically isn't bijective, and so the default `getjacobian`
+    # used in the ChangesOfVariables.jl tests will fail as the jacobian will have determinant 0.
+    # Hence, we disable those tests.
+    test_bijector(b, x; test_not_identity=true, changes_of_variables_test=false)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ if GROUP == "All" || GROUP == "Interface"
     include("bijectors/leaky_relu.jl")
     include("bijectors/coupling.jl")
     include("bijectors/ordered.jl")
+    include("bijectors/pd.jl")
 end
 
 if GROUP == "All" || GROUP == "AD"


### PR DESCRIPTION
Also added more informative error message in the case of missing `with_logabsdet_jacobian` implementation when calling `transform` and `logabsdetjac`.