### PR TITLE
Implementation of `VecCorrBijector`

### DIFF
--- a/src/bijectors/pd.jl
+++ b/src/bijectors/pd.jl
@@ -18,6 +18,8 @@ function transform(ib::Inverse{PDBijector}, Y::AbstractMatrix{<:Real})
     X = replace_diag(exp, Y)
     return getpd(X)
 end
+
+# TODO: AFAIK this is used because of AD-related issues; can we remove?
 getpd(X) = LowerTriangular(X) * LowerTriangular(X)'
 
 function logabsdetjac(b::PDBijector, X::AbstractMatrix{<:Real})

--- a/test/bijectors/corr.jl
+++ b/test/bijectors/corr.jl
@@ -1,0 +1,35 @@
+using Bijectors, DistributionsAD, LinearAlgebra, Test
+using Bijectors: VecCorrBijector, CorrBijector
+
+@testset "PDBijector" begin
+    d = 3
+
+    b = CorrBijector()
+    bvec = VecCorrBijector()
+
+    dist = LKJ(d, 1)
+    x = rand(dist)
+
+    y = b(x)
+    yvec = bvec(x)
+
+    # Make sure that they represent the same thing.
+    @test Bijectors.triu1_to_vec(y) ≈ yvec
+
+    # Check the inverse.
+    binv = inverse(b)
+    xinv = binv(y)
+    bvecinv = inverse(bvec)
+    xvecinv = bvecinv(yvec)
+
+    @test xinv ≈ xvecinv
+
+    # And finally that the `logabsdetjac` is the same.
+    @test logabsdetjac(bvec, x) ≈ logabsdetjac(b, x)
+    
+    # NOTE: `CorrBijector` technically isn't bijective, and so the default `getjacobian`
+    # used in the ChangesOfVariables.jl tests will fail as the jacobian will have determinant 0.
+    # Hence, we disable those tests.
+    test_bijector(b, x; test_not_identity=true, changes_of_variables_test=false)
+    test_bijector(bvec, x; test_not_identity=true, changes_of_variables_test=false)
+end


### PR DESCRIPTION
This PR implements a `VecCorrBijector`, i.e. `CorrBijector` but where the unconstrained space is treated as a `Vector` of the correct size rather than working with a `Matrix` which is actually embedded in a subspace of matrices.

This is particularly when doing stuff like MCMC sampling, where the full matrix representation might give the sampler the false indication that the dimension is `d × d` instead of `(d choose 2)` (as is the case here).