### PR TITLE
Fix for BijectorsZygoteExt.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.12.7"
+version = "0.12.8"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/ext/BijectorsZygoteExt.jl
+++ b/ext/BijectorsZygoteExt.jl
@@ -31,7 +31,8 @@ if isdefined(Base, :get_extension)
         pd_link,
         pd_from_lower,
         lower_triangular,
-        upper_triangular
+        upper_triangular,
+        getlogp
 
     using Bijectors.LinearAlgebra
     using Bijectors.Compat: eachcol
@@ -67,7 +68,8 @@ else
         pd_link,
         pd_from_lower,
         lower_triangular,
-        upper_triangular
+        upper_triangular,
+        getlogp
 
     using ..Bijectors.LinearAlgebra
     using ..Bijectors.Compat: eachcol


### PR DESCRIPTION
_Now_ we should have caught all the references. This slipped through the tests though, which is not great. This is really because we are lacking in AD tests. I'll make an issue regarding this.