### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bijectors.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://turinglang.github.io/Bijectors.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://turinglang.github.io/Bijectors.jl/dev)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://turinglang.github.io/library/Bijectors.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://turinglang.org/library/Bijectors/dev/)
 [![Interface tests](https://github.com/TuringLang/Bijectors.jl/workflows/Interface%20tests/badge.svg?branch=master)](https://github.com/TuringLang/Bijectors.jl/actions?query=workflow%3A%22Interface+tests%22+branch%3Amaster)
 [![AD tests](https://github.com/TuringLang/Bijectors.jl/workflows/AD%20tests/badge.svg?branch=master)](https://github.com/TuringLang/Bijectors.jl/actions?query=workflow%3A%22AD+tests%22+branch%3Amaster)
 
@@ -9,7 +9,7 @@
 
 Bijectors.jl implements both an interface for transforming distributions from Distributions.jl and many transformations needed in this context. This package is used heavily in the probabilistic programing language Turing.jl.
 
-See the [documentation](https://turinglang.github.io/Bijectors.jl) for more.
+See the [documentation](https://turinglang.org/library/Bijectors/dev/) for more.
 
 ## Do you want to contribute?
 


### PR DESCRIPTION
Some of the links were missing the `library` part of the URL. 

I noticed that our docs don't seem to render the stable URL though (https://turinglang.github.io/Bijectors.jl/stable) -- not sure why that is.