### PR TITLE
Use `parent` when `fill!` a triangular matrix

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,7 +30,7 @@ function triu_mask(X::AbstractMatrix, k::Int)
 
     # Using `similar` allows us to respect device of array, etc., e.g. `CuArray`.
     m = similar(X, Bool)
-    return triu!(fill!(m, true), k)
+    return triu!(fill!(parent(m), true), k)
 end
 
 ChainRulesCore.@non_differentiable triu_mask(X::AbstractMatrix, k::Int)


### PR DESCRIPTION
`fill!` does not work with triangular matrices (nor does `.=`). Here we access the `parent` type of a triangular matrix before filling as per @torfjelde 's suggestion. 

Fixes some issues in https://github.com/TuringLang/Turing.jl/pull/2018