### PR TITLE
Allow different types for upper and lower bound in `Logit`

### DIFF
--- a/src/bijectors/logit.jl
+++ b/src/bijectors/logit.jl
@@ -1,9 +1,9 @@
 ######################
 # Logit and Logistic #
 ######################
-struct Logit{T} <: Bijector
-    a::T
-    b::T
+struct Logit{T1,T2} <: Bijector
+    a::T1
+    b::T2
 end
 
 Functors.@functor Logit


### PR DESCRIPTION
Currently the lower bound and upper bound are forced to be the same type, which removes the possibility of computing gradients wrt. just one of the parameter.

This PR just removes this restriction.