### PR TITLE
fix `Stacked` to work with Zygote

### DIFF
--- a/test/ad/stacked.jl
+++ b/test/ad/stacked.jl
@@ -1,0 +1,27 @@
+@testset "AD for StackedBijector" begin
+    dist1 = Dirichlet(4, 1.0)
+    b1 = bijector(dist1)
+
+    dist2 = LogNormal(0.0, 1.0)
+    b2 = bijector(dist2)
+
+    x1 = rand(dist1)
+    x2 = rand(dist2)
+    
+    y1 = b1(x1)
+    y2 = b2(x2)
+
+    b = Stacked((b1, b2), (1:4, 5:5))
+    binv = inverse(b)
+
+    y = vcat(y1, [y2])
+    x = binv(y)
+
+    test_ad(y) do x
+        sum(transform(b, binv(x)))
+    end
+
+    test_ad(y) do y
+        sum(transform(binv, y))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,4 +62,5 @@ if GROUP == "All" || GROUP == "AD"
     include("ad/flows.jl")
     include("ad/pd.jl")
     include("ad/corr.jl")
+    include("ad/stacked.jl")
 end


### PR DESCRIPTION
This fixes #252 and also the corresponding issue [downstream](https://github.com/TuringLang/Turing.jl/issues/1988#issue-1697025369).

I checked that the performance (both AD and forward) is pretty much the same (slightly better in my setup) as the previous implementation. Interestingly, doing `mapreduce(f, vcat)` on `ys` performed consistently worse than doing `map`+`reduce(vcat)` and also the previous implementation.