### PR TITLE
Drop the version number 0.13.18 -> 0.13.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.13.18"
+version = "0.13.17"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"


### PR DESCRIPTION
We actually never release 0.13.17, but did then bump further to 0.13.18. Undoing that, so that JuliaRegistrator doesn't complain about non-consecutive version numbers.