### PR TITLE
Fix logpdf_with_trans(::Dirichlet, ::Vector{Real})

### DIFF
--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -164,7 +164,7 @@ function logpdf_with_trans(d::Distribution, x, transform::Bool)
     if ispd(d)
         return pd_logpdf_with_trans(d, x, transform)
     elseif isdirichlet(d)
-        l = logpdf(d, x .+ eps(eltype(x)))
+        l = logpdf(d, x .+ _eps(eltype(x)))
     else
         l = logpdf(d, x)
     end


### PR DESCRIPTION
Evaluating `logpdf_with_trans` for a Dirichlet distribution and sample of type `Vector{Real}` was failing because the wrong `eps` function was being used. This fixes that and adds tests that would have caught the issue, and any similar issues with other distributions.