### PR TITLE
Disable precompilation of BijectorsEnzymeExt on Julia 1.11+

### DIFF
--- a/.github/workflows/AD.yml
+++ b/.github/workflows/AD.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
+      fail-fast: false
       matrix:
         version:
           - '1.6'

--- a/.github/workflows/Interface.yml
+++ b/.github/workflows/Interface.yml
@@ -10,8 +10,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
+      fail-fast: false
       matrix:
         version:
           - '1.6'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.13.18"
+version = "0.13.19"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/ext/BijectorsEnzymeExt.jl
+++ b/ext/BijectorsEnzymeExt.jl
@@ -8,7 +8,23 @@ else
     using ..Bijectors: find_alpha
 end
 
-@import_rrule typeof(find_alpha) Real Real Real
-@import_frule typeof(find_alpha) Real Real Real
+# Julia 1.11.1 caused a change in the ordering of precompilation for extensions.
+# https://github.com/TuringLang/Bijectors.jl/issues/332
+# See https://github.com/JuliaLang/julia/issues/56204
+@static if v"1.11.1" <= VERSION < v"1.12"
+    function __init__()
+        if !Base.generating_output()
+            eval(
+                quote
+                    @import_rrule typeof(find_alpha) Real Real Real
+                    @import_frule typeof(find_alpha) Real Real Real
+                end,
+            )
+        end
+    end
+else
+    @import_rrule typeof(find_alpha) Real Real Real
+    @import_frule typeof(find_alpha) Real Real Real
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,3 @@
-using Bijectors
-
 using ChainRulesTestUtils
 using Combinatorics
 using DistributionsAD
@@ -11,6 +9,9 @@ using LogExpFunctions
 using ReverseDiff
 using Tracker
 using Zygote
+
+# Place below `using Enzyme`, see https://github.com/TuringLang/Bijectors.jl/pull/333
+using Bijectors
 
 using Random, LinearAlgebra, Test
 


### PR DESCRIPTION
In the following, `B = Bijectors`, `E = Enzyme`, and `C = ChainRulesCore`.

We have [`BEExt` in this repository](https://github.com/TuringLang/Bijectors.jl/blob/master/ext/BijectorsEnzymeExt.jl), and [Enzyme.jl defines `ECExt`](https://github.com/EnzymeAD/Enzyme.jl/blob/v0.12.36/ext/EnzymeChainRulesCoreExt.jl), and `B` depends on `C`. The problem is that `BEExt` depends on a method that is defined in `ECExt`, and therefore requires `ECExt` to have been loaded before `BEExt`.

In Julia 1.10.5 and 1.11.0, this requirement was somehow always satisfied. (I don't know why.)

However, https://github.com/JuliaLang/julia/pull/55589 shook this up and now, there's no guarantee that `ECExt` will be loaded first. Indeed, it turns out that in Julia 1.11.1, `BEExt` is always loaded first. The PR is slated to be backported to 1.10.6 as well. I suppose that we cannot really complain about the PR because the dependency graph in itself doesn't specify that one should be loaded before the other (the order of loading depends only on _how the dependency graph is traversed_), and we probably should not be relying on that implicit behaviour. Although the discussion in https://github.com/JuliaLang/julia/pull/55589 suggests that we might one day be able to explicitly specify dependencies between extensions (i.e. adding an extra edge to the dependency graph), this isn't in place yet.

Anyway, the result of this is that precompilation fails when adding Bijectors and Enzyme to an environment, as reported in #332.

--------

This PR uses a workaround described in https://github.com/JuliaLang/julia/issues/56204 to disable precompilation for `BEExt`, so that we can at least add Bijectors and Enzyme to the same environment.

It doesn't fully solve the issue at runtime, though. At runtime, we can – to some extent – control the order of loading. If we run `using E` before `using B`, then `ECExt` gets loaded first, and all is good. But if we run `using B` first, then `BEExt` is loaded, and we get an error.

I don't know how to fully solve the runtime issue, but this PR will at least solve the precomp issue.

------------

Closes #332 (in the sense that it fixes the immediate problem of precompilation failing; the _root cause_ of this issue is really the underspecified dependency graph, but there isn't a fix for that)