### PR TITLE
Bump Julia compat entry to 1.10

### DIFF
--- a/.github/workflows/AD.yml
+++ b/.github/workflows/AD.yml
@@ -28,8 +28,8 @@ jobs:
           - ReverseDiff
           - Zygote
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/AD.yml
+++ b/.github/workflows/AD.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'min'
           - '1'
         os:
           - ubuntu-latest
@@ -27,13 +27,6 @@ jobs:
           - Tracker
           - ReverseDiff
           - Zygote
-        exclude:
-          - version: 1.6
-            AD: Mooncake
-          # TODO(mhauru) Hopefully can enable Enzyme on older versions at some point, see
-          # discussion in https://github.com/TuringLang/Bijectors.jl/pull.
-          - version: 1.6
-            AD: Enzyme
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Interface.yml
+++ b/.github/workflows/Interface.yml
@@ -22,8 +22,8 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/Interface.yml
+++ b/.github/workflows/Interface.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'min'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -69,7 +69,7 @@ Statistics = "1"
 Mooncake = "0.4.19"
 Tracker = "0.2"
 Zygote = "0.6.63"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c"


### PR DESCRIPTION
Mooncake, and Enzyme 0.13, and Turing, only support Julia 1.10+ so I figure we may as well drop support for anything before it.

I tidied up the GHA workflows a bit too.