### PR TITLE
Use ITP as root-finding algorithm in planar layer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -65,7 +65,7 @@ MappedArrays = "0.2.2, 0.3, 0.4"
 Reexport = "0.2, 1"
 Requires = "0.5, 1"
 ReverseDiff = "1"
-Roots = "1.3.4, 2"
+Roots = "1.3.15, 2"
 Statistics = "1"
 Mooncake = "0.4.19"
 Tracker = "0.2"

--- a/src/bijectors/planar_layer.jl
+++ b/src/bijectors/planar_layer.jl
@@ -173,7 +173,7 @@ function find_alpha(wt_y::T, wt_u_hat::T, b::T) where {T<:Real}
     end
 
     # Solve the root-finding problem
-    α0 = Roots.find_zero((lower, upper)) do α
+    α0 = Roots.find_zero((lower, upper), Roots.ITP()) do α
         return α + wt_u_hat * tanh(α + b) - wt_y
     end
 


### PR DESCRIPTION
As recommended in https://github.com/EnzymeAD/Enzyme.jl/issues/2035#issuecomment-2455063492 for increased robustness.

ITP was added in Roots 1.3.15: https://github.com/JuliaMath/Roots.jl/pull/274