### PR TITLE
Add docs for `link`, `invlink`, and `logpdf_with_trans`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/Manifest.toml
-/test/Manifest.toml
+Manifest.toml
+docs/build

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.14.1"
+version = "0.14.2"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,15 @@
 # Bijectors.jl
 
-This package implements a set of functions for transforming constrained random variables (e.g. simplexes, intervals) to Euclidean space. The 3 main functions implemented in this package are the `link`, `invlink` and `logpdf_with_trans` for a number of distributions. The distributions supported are:
+This package implements a set of functions for transforming constrained random variables (e.g. simplexes, intervals) to Euclidean space.
+The 3 main functions implemented in this package are the `link`, `invlink` and `logpdf_with_trans` for a number of distributions.
+
+```@docs
+Bijectors.link
+Bijectors.invlink
+Bijectors.logpdf_with_trans
+```
+
+The distributions supported are:
 
  1. `RealDistribution`: `Union{Cauchy, Gumbel, Laplace, Logistic, NoncentralT, Normal, NormalCanon, TDist}`,
  2. `PositiveDistribution`: `Union{BetaPrime, Chi, Chisq, Erlang, Exponential, FDist, Frechet, Gamma, InverseGamma, InverseGaussian, Kolmogorov, LogNormal, NoncentralChisq, NoncentralF, Rayleigh, Weibull}`,

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -79,10 +79,6 @@ export TransformDistribution,
     InvertibleBatchNorm,
     elementwise
 
-if VERSION < v"1.1"
-    using Compat: eachcol
-end
-
 if VERSION < v"1.9"
     using Compat: stack
 end

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -214,10 +214,13 @@ _logabsdetjac_dist(d::LKJCholesky, x::AbstractVector) = logabsdetjac.((bijector(
 If `transform` is `false`, `logpdf_with_trans` calculates the log probability
 density function (logpdf) of distribution `d` at `x`.
 
-If `transform` is `true`, the logpdf is calculated after transforming `x` using
-the constrained-to-unconstrained bijector for distribution `d`. Specifically,
-if `x` is distributed according to `d` and `y = link(d, x)` is distributed
-according to `td`, then `logpdf_with_trans(d, x, true) = logpdf(td, y)`.
+If `transform` is `true`, `x` is transformed using the
+constrained-to-unconstrained bijector for distribution `d`, and then the logpdf
+of the resulting value is calculated with respect to the unconstrained
+(transformed) distribution. Equivalently, if `x` is distributed according to
+`d` and `y = link(d, x)` is distributed according to `td = transformed(d)`,
+then `logpdf_with_trans(d, x, true) = logpdf(td, y)`. This is accomplished
+by subtracting the log Jacobian of the transformation.
 
 # Example
 
@@ -233,8 +236,13 @@ julia> logpdf(LogNormal(), ℯ)  # Same as above
 julia> logpdf_with_trans(LogNormal(), ℯ, true)
 -1.4189385332046727
 
-julia> logpdf(Normal(), 1.0)   # If x ~ LogNormal(), then log(x) ~ Normal()
+julia> # If x ~ LogNormal(), then log(x) ~ Normal()
+       logpdf(Normal(), 1.0)   
 -1.4189385332046727
+
+julia> # The difference between the two is due to the Jacobian
+       logabsdetjac(bijector(LogNormal()), ℯ)
+-1
 ```
 """
 function logpdf_with_trans(d::Distribution, x, transform::Bool)

--- a/src/bijectors/coupling.jl
+++ b/src/bijectors/coupling.jl
@@ -166,7 +166,7 @@ julia> coupling(cl) # get the `Bijector` map `θ -> b(⋅, θ)`
 Shift
 
 julia> couple(cl, x) # get the `Bijector` resulting from `x`
-Shift([2.0])
+Shift{Vector{Float64}}([2.0])
 
 julia> with_logabsdet_jacobian(cl, x)
 ([3.0, 2.0, 3.0], 0.0)


### PR DESCRIPTION
The docs currently write (https://turinglang.org/Bijectors.jl/stable/):

> The 3 main functions implemented in this package are the link, invlink and logpdf_with_trans for a number of distributions.

However, none of these functions are documented. This PR fixes that.