### PR TITLE
Bump minor version to 0.15

### DIFF
--- a/.github/workflows/AD.yml
+++ b/.github/workflows/AD.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
 
       - uses: julia-actions/julia-runtest@v1
-        continue-on-error: ${{ matrix.AD == 'Enzyme' }}
+        continue-on-error: ${{ matrix.AD == 'Enzyme' && matrix.version == '1' }}
         env:
           GROUP: AD
           AD: ${{ matrix.AD }}

--- a/.github/workflows/AD.yml
+++ b/.github/workflows/AD.yml
@@ -15,12 +15,13 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.AD == 'Enzyme' }}
+
     strategy:
       fail-fast: false
       matrix:
         version:
           - 'min'
-          - 'lts'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/AD.yml
+++ b/.github/workflows/AD.yml
@@ -15,8 +15,6 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.AD == 'Enzyme' }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -35,11 +33,15 @@ jobs:
           - Zygote
     steps:
       - uses: actions/checkout@v4
+
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
+
       - uses: julia-actions/julia-buildpkg@v1
+
       - uses: julia-actions/julia-runtest@v1
+        continue-on-error: ${{ matrix.AD == 'Enzyme' }}
         env:
           GROUP: AD
           AD: ${{ matrix.AD }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.14.2"
+version = "0.14.3"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.14.3"
+version = "0.15"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"


### PR DESCRIPTION
Raises minimum Julia version to v1.10 and bumps EnzymeCore compat to latest, with the manual `find_alpha` rule.

~Could also bump the minor, rather than patch, version, because of the changing Julia compat. This shouldn't cause breakage for anyone who manages to install it, so in that sense it's not breaking, but bumping Julia versions could still be considered a "major" thing. Do we have a convention for this in Julia-land or Turing-land?~ EDIT: See later comments, decided to go with a minor 