### PR TITLE
Fix for some type instabilities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.15"
+version = "0.15.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/Bijectors.jl
+++ b/src/Bijectors.jl
@@ -191,7 +191,7 @@ function _logabsdetjac_dist(d::MultivariateDistribution, x::AbstractVector)
     return logabsdetjac(bijector(d), x)
 end
 function _logabsdetjac_dist(d::MultivariateDistribution, x::AbstractMatrix)
-    return logabsdetjac.((bijector(d),), eachcol(x))
+    return map(Base.Fix1(logabsdetjac, bijector(d)), eachcol(x))
 end
 
 _logabsdetjac_dist(d::MatrixDistribution, x::AbstractMatrix) = logabsdetjac(bijector(d), x)


### PR DESCRIPTION
_Sometimes_ we encounter type instabilities in the current impl of `logpdf_with_trans` for "batched" with `MultivariateDistribution`. This is caused by broadcasting over a `tuple` of bijector + an `eachcol`.

See https://github.com/TuringLang/DynamicPPL.jl/pull/728#issuecomment-2508896076 for an example.

This PR replaces that broadcast with a much more stable `map` + `Fix1`. This at least fixes the issue encountered in the referenced PR to DPPL.jl, and just seems better overall.