### PR TITLE
Fix infinite recursion in CorrBijector/VecCorrBijector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -65,13 +65,13 @@ struct CorrBijector <: Bijector end
 
 with_logabsdet_jacobian(b::CorrBijector, x) = transform(b, x), logabsdetjac(b, x)
 
-function transform(b::CorrBijector, X::AbstractMatrix{<:Real})
+function transform(b::CorrBijector, X)
     w = cholesky_upper(X)
     r = _link_chol_lkj(w)
     return r
 end
 
-function with_logabsdet_jacobian(ib::Inverse{CorrBijector}, y::AbstractMatrix{<:Real})
+function with_logabsdet_jacobian(ib::Inverse{CorrBijector}, y)
     U, logJ = _inv_link_chol_lkj(y)
     K = size(U, 1)
     for j in 2:(K - 1)
@@ -80,8 +80,8 @@ function with_logabsdet_jacobian(ib::Inverse{CorrBijector}, y::AbstractMatrix{<:
     return pd_from_upper(U), logJ
 end
 
-logabsdetjac(::Inverse{CorrBijector}, Y::AbstractMatrix{<:Real}) = _logabsdetjac_inv_corr(Y)
-function logabsdetjac(b::CorrBijector, X::AbstractMatrix{<:Real})
+logabsdetjac(::Inverse{CorrBijector}, Y) = _logabsdetjac_inv_corr(Y)
+function logabsdetjac(b::CorrBijector, X)
     #=
     It may be more efficient if we can use un-contraint value to prevent call of b
     It's recommended to directly call 
@@ -135,7 +135,7 @@ function logabsdetjac(b::VecCorrBijector, x)
     return -logabsdetjac(inverse(b), b(x))
 end
 
-function with_logabsdet_jacobian(::Inverse{VecCorrBijector}, y::AbstractVector{<:Real})
+function with_logabsdet_jacobian(::Inverse{VecCorrBijector}, y)
     U_logJ = _inv_link_chol_lkj(y)
     # workaround for `Tracker.TrackedTuple` not supporting iteration
     U, logJ = U_logJ[1], U_logJ[2]
@@ -146,7 +146,7 @@ function with_logabsdet_jacobian(::Inverse{VecCorrBijector}, y::AbstractVector{<
     return pd_from_upper(U), logJ
 end
 
-function logabsdetjac(::Inverse{VecCorrBijector}, y::AbstractVector{<:Real})
+function logabsdetjac(::Inverse{VecCorrBijector}, y)
     return _logabsdetjac_inv_corr(y)
 end
 


### PR DESCRIPTION
Closes #320 

With this PR:

```julia
julia> using Bijectors: CorrBijector, VecCorrBijector, inverse

julia> v = [1.0]; m = [[1.0]]
1-element Vector{Vector{Float64}}:
 [1.0]

julia> CorrBijector()(v)
ERROR: MethodError: no method matching cholesky_upper(::Vector{Float64})

julia> inverse(CorrBijector())(m)
ERROR: MethodError: no method matching AbstractFloat(::Type{Vector{Float64}})

julia> inverse(VecCorrBijector())(m)
ERROR: MethodError: no method matching AbstractFloat(::Type{Vector{Float64}})
```

Previously, all of these would fail with StackOverflowError due to infinite recursion between 

https://github.com/TuringLang/Bijectors.jl/blob/55501ae8e6fbb414b743fdf10be34f3275616464/src/interface.jl#L92-L93

and

https://github.com/TuringLang/Bijectors.jl/blob/55501ae8e6fbb414b743fdf10be34f3275616464/src/interface.jl#L213-L216

or in the case of CorrBijector

https://github.com/TuringLang/Bijectors.jl/blob/55501ae8e6fbb414b743fdf10be34f3275616464/src/bijectors/corr.jl#L66