### PR TITLE
Use DOCUMENTER_KEY for CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,5 +14,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs = ["", "test"])'


### PR DESCRIPTION
The old COMPATHELPER_PRIV secret was 5 years old, so I think probably doesn't work anymore with GitHub & triggering CI on CompatHelper runs.