### PR TITLE
Remove incorrect mapvcat Zygote adjoint

### DIFF
--- a/ext/BijectorsZygoteExt.jl
+++ b/ext/BijectorsZygoteExt.jl
@@ -22,7 +22,6 @@ using Bijectors:
     find_alpha,
     pd_logpdf_with_trans,
     istraining,
-    mapvcat,
     eachcolmaphcat,
     sumeachcol,
     pd_link,
@@ -36,10 +35,6 @@ using Bijectors.Distributions: LocationScale
 
 @adjoint istraining() = true, _ -> nothing
 
-@adjoint function mapvcat(f, args...)
-    g(f, args...) = map(f, args...)
-    return pullback(g, f, args...)
-end
 @adjoint function eachcolmaphcat(f, x1, x2)
     function g(f, x1, x2)
         init = reshape(f(view(x1, :, 1), x2[1]), :, 1)

--- a/test/ad/stacked.jl
+++ b/test/ad/stacked.jl
@@ -24,4 +24,15 @@
     test_ad(y) do y
         sum(transform(binv, y))
     end
+
+    bvec = Stacked([b1, b2], [1:4, 5:5])
+    bvec_inv = inverse(bvec)
+
+    test_ad(y) do x
+        sum(transform(bvec, binv(x)))
+    end
+
+    test_ad(y) do y
+        sum(transform(bvec_inv, y))
+    end
 end


### PR DESCRIPTION
We define a `Zygote.@adjoint` for `mapvcat` manually. This seems unnecessary to me. Moreover, the implementation is wrong, since it ignores the `vcat` part of `mapvcat`. I've added a test that would have caught this.

Closes #361