### PR TITLE
RationalQuadraticSpline for batch dimension

### DIFF
--- a/src/bijectors/rational_quadratic_spline.jl
+++ b/src/bijectors/rational_quadratic_spline.jl
@@ -177,6 +177,10 @@ function transform(b::RationalQuadraticSpline{<:AbstractMatrix}, x::AbstractVect
     ]
 end
 
+function transform(b::RationalQuadraticSpline{<:AbstractMatrix}, x::AbstractMatrix)
+	return mapreduce(b, hcat, eachcol(x))
+end
+
 ##########################
 ### Inverse evaluation ###
 ##########################


### PR DESCRIPTION
This PR enables using `RationalQuadraticSpline` with `Couplings` on matrix dimension

```julia
b = RationalQuadraticSpline(rand(11,5), rand(11,5), rand(11,5)) # 11 nodes, batch of 5
b(rand(1, 5)) # should return matrix of dim (1, 5) to be able to `combine` 
```

