### PR TITLE
Trying to organise the tests, part 1

### DIFF
--- a/.github/workflows/AD.yml
+++ b/.github/workflows/AD.yml
@@ -23,7 +23,6 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
         AD:
           - Enzyme
           - ForwardDiff

--- a/.github/workflows/Interface.yml
+++ b/.github/workflows/Interface.yml
@@ -20,11 +20,9 @@ jobs:
       matrix:
         version:
           - 'min'
-          - 'lts'
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/test/ad/corr.jl
+++ b/test/ad/corr.jl
@@ -1,35 +1,37 @@
 @testset "AD for VecCorrBijector" begin
-    d = 4
-    dist = LKJ(d, 2.0)
-    b = bijector(dist)
-    binv = inverse(b)
+    @testset "d = $d" for d in (1, 2, 4)
+        dist = LKJ(d, 2.0)
+        b = bijector(dist)
+        binv = inverse(b)
 
-    x = rand(dist)
-    y = b(x)
+        x = rand(dist)
+        y = b(x)
 
-    test_ad(y) do x
-        sum(transform(b, binv(x)))
-    end
-
-    test_ad(y) do y
-        sum(transform(binv, y))
+        # roundtrip
+        test_ad(y -> sum(transform(b, binv(y))), y)
+        # inverse only
+        test_ad(y -> sum(transform(binv, y)), y)
     end
 end
 
 @testset "AD for VecCholeskyBijector" begin
-    d = 4
-    dist = LKJCholesky(d, 2.0)
-    b = bijector(dist)
-    binv = inverse(b)
+    @testset "d = $d, uplo = $uplo" for d in (1, 2, 4), uplo in ('U', 'L')
+        dist = LKJCholesky(d, 2.0, uplo)
+        b = bijector(dist)
+        binv = inverse(b)
 
-    x = rand(dist)
-    y = b(x)
+        x = rand(dist)
+        y = b(x)
 
-    test_ad(y) do y
-        sum(transform(b, binv(y)))
-    end
-
-    test_ad(y) do y
-        sum(Bijectors.cholesky_upper(transform(binv, y)))
+        # roundtrip
+        test_ad(y -> sum(transform(b, binv(y))), y)
+        # inverse only
+        test_ad(y -> sum(transform(binv, y)), y)
+        # additionally check that cholesky_{upper,lower} is differentiable
+        if uplo == 'U'
+            test_ad(y -> sum(Bijectors.cholesky_upper(transform(b, y))), y)
+        else
+            test_ad(y -> sum(Bijectors.cholesky_lower(transform(b, y))), y)
+        end
     end
 end

--- a/test/ad/corr.jl
+++ b/test/ad/corr.jl
@@ -25,13 +25,13 @@ end
 
         # roundtrip
         test_ad(y -> sum(transform(b, binv(y))), y)
-        # inverse only
-        test_ad(y -> sum(transform(binv, y)), y)
-        # additionally check that cholesky_{upper,lower} is differentiable
+        # inverse (we need to tack on `cholesky_upper`/`cholesky_lower`,
+        # because directly calling `sum` on a LinearAlgebra.Cholesky doesn't
+        # give a scalar)
         if uplo == 'U'
-            test_ad(y -> sum(Bijectors.cholesky_upper(transform(b, y))), y)
+            test_ad(y -> sum(Bijectors.cholesky_upper(transform(binv, y))), y)
         else
-            test_ad(y -> sum(Bijectors.cholesky_lower(transform(b, y))), y)
+            test_ad(y -> sum(Bijectors.cholesky_lower(transform(binv, y))), y)
         end
     end
 end

--- a/test/ad/utils.jl
+++ b/test/ad/utils.jl
@@ -1,3 +1,6 @@
+# Figure out which AD backend to test
+const AD = get(ENV, "AD", "All")
+
 function test_ad(f, x, broken=(); rtol=1e-6, atol=1e-6)
     for b in broken
         if !(

--- a/test/ad/utils.jl
+++ b/test/ad/utils.jl
@@ -1,6 +1,3 @@
-# Figure out which AD backend to test
-const AD = get(ENV, "AD", "All")
-
 function test_ad(f, x, broken=(); rtol=1e-6, atol=1e-6)
     for b in broken
         if !(

--- a/test/bijectors/corr.jl
+++ b/test/bijectors/corr.jl
@@ -32,8 +32,6 @@ using Bijectors: VecCorrBijector, VecCholeskyBijector, CorrBijector
         test_bijector(b, x; test_not_identity=d != 1, changes_of_variables_test=false)
         test_bijector(bvec, x; test_not_identity=d != 1, changes_of_variables_test=false)
 
-        test_ad(x -> sum(bvec(bvecinv(x))), yvec)
-
         # Check that output sizes are computed correctly.
         tdist = transformed(dist)
         @test length(tdist) == length(yvec)
@@ -63,8 +61,6 @@ end
             xinv_lkj = binv_lkj(y_lkj)
 
             @test xinv.U ≈ cholesky(xinv_lkj).U
-
-            test_ad(x -> sum(b(binv(x))), y)
 
             # test_bijector is commented out for now, 
             # as isapprox is not defined for ::Cholesky types (the domain of LKJCholesky)

--- a/test/bijectors/utils.jl
+++ b/test/bijectors/utils.jl
@@ -108,19 +108,3 @@ function test_functor(x, xs)
     @test x == re(_xs)
     @test _xs == xs
 end
-
-function test_bijector_parameter_gradient(b::Bijectors.Transform, x, y=b(x))
-    args, re = Functors.functor(b)
-    recon(k, param) = re(merge(args, NamedTuple{(k,)}((param,))))
-
-    # Compute the gradient wrt. one argument at the time.
-    for (k, v) in pairs(args)
-        test_ad(p -> sum(transform(recon(k, p), x)), v)
-        test_ad(p -> logabsdetjac(recon(k, p), x), v)
-
-        if Bijectors.isinvertible(b)
-            test_ad(p -> sum(transform(inv(recon(k, p)), y)), v)
-            test_ad(p -> logabsdetjac(inv(recon(k, p)), y), v)
-        end
-    end
-end


### PR DESCRIPTION
In the Bijectors test suite there are two kinds of AD tests:

1. Check that the manual implementation of `Bijectors.logabsdetjac` returns the same numerical result as an AD backend (I think we should ideally like to always use FiniteDifferences, but in some cases we use ForwardDiff). This usually involves a manual call to `ForwardDiff.jacobian` or similar.

2. Check that AD backends can differentiate through Bijectors code. This uses the `test_ad` function.

Generally these fall under the 'interface' / 'AD' test suite respectively.

But there are a couple of stragglers where the `test_ad` function is being called in the interface tests. This PR gets rid of the exceptions.

This PR also streamlines CI a bit:

- Removes macOS, I don't think it gives us any extra information over Ubuntu. It also makes it quite hard for other packages to get macOS runners for CI.
- Don't test `min` and `lts` separately (our min compat is 1.10.8 and lts is 1.10.10 so it's really no different).