### PR TITLE
Disable the Enzyme rule test on 1.11

### DIFF
--- a/test/ad/enzyme.jl
+++ b/test/ad/enzyme.jl
@@ -23,43 +23,45 @@ using Test
 # `@test_throws`. Consequently `@test_throws` doesn't actually see any error. Weird Julia
 # behaviour.
 
-@testset "Enzyme: Bijectors.find_alpha" begin
-    x = randn()
-    y = expm1(randn())
-    z = randn()
+@static if VERSION < v"1.11"
+    @testset "Enzyme: Bijectors.find_alpha" begin
+        x = randn()
+        y = expm1(randn())
+        z = randn()
 
-    @testset "forward" begin
-        # No batches
-        @testset for RT in (Const, Duplicated, DuplicatedNoNeed),
-            Tx in (Const, Duplicated),
-            Ty in (Const, Duplicated),
-            Tz in (Const, Duplicated)
+        @testset "forward" begin
+            # No batches
+            @testset for RT in (Const, Duplicated, DuplicatedNoNeed),
+                Tx in (Const, Duplicated),
+                Ty in (Const, Duplicated),
+                Tz in (Const, Duplicated)
 
-            test_forward(Bijectors.find_alpha, RT, (x, Tx), (y, Ty), (z, Tz))
+                test_forward(Bijectors.find_alpha, RT, (x, Tx), (y, Ty), (z, Tz))
+            end
+
+            # Batches
+            @testset for RT in (Const, BatchDuplicated, BatchDuplicatedNoNeed),
+                Tx in (Const, BatchDuplicated),
+                Ty in (Const, BatchDuplicated),
+                Tz in (Const, BatchDuplicated)
+
+                test_forward(Bijectors.find_alpha, RT, (x, Tx), (y, Ty), (z, Tz))
+            end
         end
+        @testset "reverse" begin
+            # No batches
+            @testset for RT in (Const, Active),
+                Tx in (Const, Active),
+                Ty in (Const, Active),
+                Tz in (Const, Active)
 
-        # Batches
-        @testset for RT in (Const, BatchDuplicated, BatchDuplicatedNoNeed),
-            Tx in (Const, BatchDuplicated),
-            Ty in (Const, BatchDuplicated),
-            Tz in (Const, BatchDuplicated)
+                test_reverse(Bijectors.find_alpha, RT, (x, Tx), (y, Ty), (z, Tz))
+            end
 
-            test_forward(Bijectors.find_alpha, RT, (x, Tx), (y, Ty), (z, Tz))
+            # TODO: Test batch mode
+            # This is a bit problematic since Enzyme does not support all combinations of activities currently
+            # https://github.com/TuringLang/Bijectors.jl/pull/350#issuecomment-2480468728
         end
-    end
-    @testset "reverse" begin
-        # No batches
-        @testset for RT in (Const, Active),
-            Tx in (Const, Active),
-            Ty in (Const, Active),
-            Tz in (Const, Active)
-
-            test_reverse(Bijectors.find_alpha, RT, (x, Tx), (y, Ty), (z, Tz))
-        end
-
-        # TODO: Test batch mode
-        # This is a bit problematic since Enzyme does not support all combinations of activities currently
-        # https://github.com/TuringLang/Bijectors.jl/pull/350#issuecomment-2480468728
     end
 end
 


### PR DESCRIPTION
In #420 while adding more comments about the failing 1.11 test, I accidentally removed the check. That shouldn't have happened, so this PR re-enables the version check (although it retains all other changes in #420).