### PR TITLE
Implement vector bijectors for TransformedDistribution

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.15.22
+
+Implement vector bijectors for `Bijectors.TransformedDistribution`.
+
 # 0.15.21
 
 Add compatibility with Roots.jl v3.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.15.21"
+version = "0.15.22"
 
 [deps]
 AbstractPPL = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"

--- a/src/vector/VectorBijectors.jl
+++ b/src/vector/VectorBijectors.jl
@@ -46,6 +46,8 @@ include("cholesky/cholesky.jl")
 include("product/product.jl")
 include("product/fill.jl")
 
+include("transformed.jl")
+
 # Put last to avoid cluttering namespace
 include("test_utils.jl")
 

--- a/src/vector/transformed.jl
+++ b/src/vector/transformed.jl
@@ -1,0 +1,8 @@
+for T in (B.UnivariateTransformed, B.MultivariateTransformed, B.MatrixTransformed)
+    @eval begin
+        to_linked_vec(td::$T) = to_linked_vec(td.dist) ∘ inverse(td.transform)
+        from_linked_vec(td::$T) = td.transform ∘ from_linked_vec(td.dist)
+        linked_vec_length(td::$T) = linked_vec_length(td.dist)
+        linked_optic_vec(td::$T) = fill(nothing, linked_vec_length(td))
+    end
+end

--- a/src/vector/transformed.jl
+++ b/src/vector/transformed.jl
@@ -1,3 +1,6 @@
+# Note that to_vec, from_vec, vec_length, and optic_vec are inherited from the generic
+# UnivariateDistribution, MultivariateDistribution, and MatrixDistribution methods so
+# we don't need to define them here.
 for T in (B.UnivariateTransformed, B.MultivariateTransformed, B.MatrixTransformed)
     @eval begin
         to_linked_vec(td::$T) = to_linked_vec(td.dist) ∘ inverse(td.transform)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 AbstractPPL = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
+Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,7 @@ include("bijectors/utils.jl")
         include("vector/reshaped.jl")
         include("vector/cholesky.jl")
         include("vector/order.jl")
+        include("vector/transformed.jl")
     end
 
     if GROUP == "All" || GROUP == "VectorProduct"

--- a/test/vector/transformed.jl
+++ b/test/vector/transformed.jl
@@ -14,9 +14,9 @@ transformed_dists = [
     # Univariate
     transformed(Normal(), exp),
     transformed(Beta(2, 3), Bijectors.Logit(0.0, 1.0)),
-    transformed(Gamma(2, 1), Bijectors.Log{0}()),
+    transformed(Gamma(2, 1), elementwise(log)),
     # Multivariate
-    transformed(product_distribution(fill(Normal(), 4)), elementwise(exp)),
+    transformed(product_distribution(fill(Cauchy(), 4)), elementwise(exp)),
     transformed(MvNormal(zeros(3), I), Bijectors.Scale(2.0)),
     transformed(Dirichlet([1.0, 2.0, 3.0])),
     transformed(MvLogNormal(zeros(2), I), elementwise(log)),

--- a/test/vector/transformed.jl
+++ b/test/vector/transformed.jl
@@ -1,0 +1,31 @@
+module VBTransformedTests
+
+using Bijectors
+using Distributions
+using LinearAlgebra
+using Test
+using Bijectors.VectorBijectors
+using Enzyme: Enzyme
+using ForwardDiff: ForwardDiff
+using ReverseDiff: ReverseDiff
+using Mooncake: Mooncake
+
+transformed_dists = [
+    # Univariate
+    transformed(Normal(), exp),
+    transformed(Beta(2, 3), Bijectors.Logit(0.0, 1.0)),
+    transformed(Gamma(2, 1), Bijectors.Log{0}()),
+    # Multivariate
+    transformed(product_distribution(fill(Normal(), 4)), elementwise(exp)),
+    transformed(MvNormal(zeros(3), I), Bijectors.Scale(2.0)),
+    transformed(Dirichlet([1.0, 2.0, 3.0])),
+    transformed(MvLogNormal(zeros(2), I), elementwise(log)),
+]
+
+@testset "TransformedDistributions" begin
+    for d in transformed_dists
+        VectorBijectors.test_all(d; test_in_support=false)
+    end
+end
+
+end # module VBTransformedTests

--- a/test/vector/transformed.jl
+++ b/test/vector/transformed.jl
@@ -20,6 +20,8 @@ transformed_dists = [
     transformed(MvNormal(zeros(3), I), Bijectors.Scale(2.0)),
     transformed(Dirichlet([1.0, 2.0, 3.0])),
     transformed(MvLogNormal(zeros(2), I), elementwise(log)),
+    # Matrix
+    transformed(MatrixNormal(zeros(2, 3), I(2), I(3)), elementwise(exp)),
 ]
 
 @testset "TransformedDistributions" begin

--- a/test/vector/transformed.jl
+++ b/test/vector/transformed.jl
@@ -16,7 +16,7 @@ transformed_dists = [
     transformed(Beta(2, 3), Bijectors.Logit(0.0, 1.0)),
     transformed(Gamma(2, 1), elementwise(log)),
     # Multivariate
-    transformed(product_distribution(fill(Cauchy(), 4)), elementwise(exp)),
+    transformed(product_distribution(fill(Beta(2, 2), 4)), elementwise(exp)),
     transformed(MvNormal(zeros(3), I), Bijectors.Scale(2.0)),
     transformed(Dirichlet([1.0, 2.0, 3.0])),
     transformed(MvLogNormal(zeros(2), I), elementwise(log)),


### PR DESCRIPTION
~~Claude did this, I have yet to review~~ Done now, I am happy with it.

Closes #451.

With this PR:

```julia
julia> using Turing, Bijectors; @model function demo()
           x ~ transformed(filldist(Normal(), 4), elementwise(exp))
       end;

julia> sample(demo(), NUTS(), 10000) |> mean
┌ Info: Found initial step size
└   ϵ = 1.6
Sampling 100%|███████████████████████████████████████████████████████████████████| Time: 0:00:00
Mean

  parameters      mean
      Symbol   Float64

        x[1]    1.6259
        x[2]    1.6572
        x[3]    1.6584
        x[4]    1.6339
```

which matches the results on Turing@0.39 (before the VectorBijectors change). I did not compare performance.