### PR TITLE
Bump patch version to 0.16.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.16.2
+
+Switch the root finder in `find_alpha` from ITP to A42, which avoids the `ConvergenceFailed` error raised when the ITP bracket stalls short of convergence.
+
 # 0.16.1
 
 Add Mooncake 0.6 forward-mode support for `find_alpha`, and widen Mooncake compat to include 0.6.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.16.3
+
+Allow LogExpFunctions 1.0.
+
 # 0.16.2
 
 Switch the root finder in `find_alpha` from ITP to A42, which avoids the `ConvergenceFailed` error raised when the ITP bracket stalls short of convergence.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijectors"
 uuid = "76274a88-744f-5084-9051-94815aaf08c4"
-version = "0.16.2"
+version = "0.16.3"
 
 [deps]
 AbstractPPL = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"

--- a/docs/src/vector.md
+++ b/docs/src/vector.md
@@ -8,7 +8,7 @@ It assumes that there are three forms of samples from a distribution `d` that we
 
  2. **A vectorised form**, which is a vector that contains a flattened version of the original form.
  3. **A linked vectorised form**, which is a vector in which:
-
+    
       + each element is independent; and
       + each element is unconstrained (can take any value in ℝ).
 


### PR DESCRIPTION
Format CI has been failing on main since #486 -- fixed here.

0.16.2 was tagged without a HISTORY entry.